### PR TITLE
Read back the settings properly

### DIFF
--- a/android/java/org/mlperf/inference/MiddleInterface.java
+++ b/android/java/org/mlperf/inference/MiddleInterface.java
@@ -246,7 +246,7 @@ public final class MiddleInterface implements AutoCloseable, RunMLPerfWorker.Cal
   public BackendSetting getSettings() {
     try {
       String backendPref = sharedPref.getString(getBackendKey(), null);
-      if (backendPref != null) {
+      if (backendPref != null && !backendPref.isEmpty()) {
         return BackendSetting.parseFrom(Base64.decode(backendPref, Base64.DEFAULT));
       }
 


### PR DESCRIPTION
When passing the backend settings file from
command line, we set the shared preferences to empty
string, but when querying it back, we don't check for
empty string again. Changing that behaviour now.