### PR TITLE
Change loadgen log directory to /sdcard

### DIFF
--- a/android/java/org/mlperf/inference/MLPerfTasks.java
+++ b/android/java/org/mlperf/inference/MLPerfTasks.java
@@ -133,8 +133,7 @@ public final class MLPerfTasks {
   }
 
   public static String getResultsJsonPath() {
-    return MLCtx.getInstance().getContext().getExternalFilesDir("mlperf").getAbsolutePath()
-        + "/results.json";
+    return "/sdcard/mlperf_results/mlperf/results.json";
   }
 
   // Update the results.json file.

--- a/android/java/org/mlperf/inference/MiddleInterface.java
+++ b/android/java/org/mlperf/inference/MiddleInterface.java
@@ -26,6 +26,7 @@ import android.util.Base64;
 import android.util.Log;
 import androidx.preference.PreferenceManager;
 import java.io.IOException;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.mlperf.inference.exceptions.UnsupportedDeviceException;
@@ -189,19 +190,16 @@ public final class MiddleInterface implements AutoCloseable, RunMLPerfWorker.Cal
         batch = 1;
       }
       if (runMode.equals(AppConstants.SUBMISSION_MODE)) {
-        String logDir =
-            MLCtx.getInstance()
-                .getContext()
-                .getExternalFilesDir("log_performance/" + bm.getId())
-                .getAbsolutePath();
-
+        String logDir = "/sdcard/mlperf_results/log_performance/" + bm.getId();
+        File appDir = new File(logDir);
+        appDir.mkdirs();
+        Log.d(TAG,"log_performance file path: " + logDir);
         startingList[counter] =
             new StartData(bm.getId(), logDir, AppConstants.PERFORMANCE_LITE_MODE, batch);
-        logDir =
-            MLCtx.getInstance()
-                .getContext()
-                .getExternalFilesDir("log_accuracy/" + bm.getId())
-                .getAbsolutePath();
+        logDir = "/sdcard/mlperf_results/log_accuracy/" + bm.getId();
+        appDir = new File(logDir);
+        appDir.mkdirs();
+        Log.d(TAG,"log_accuracy file path: " + logDir);
 
         startingList[counter + benchmarksSize] =
             new StartData(bm.getId(), logDir, AppConstants.ACCURACY_MODE, batch);
@@ -216,11 +214,10 @@ public final class MiddleInterface implements AutoCloseable, RunMLPerfWorker.Cal
         } else {
           logDirBase = "log_undefined/";
         }
-        String logDir =
-            MLCtx.getInstance()
-                .getContext()
-                .getExternalFilesDir(logDirBase + bm.getId())
-                .getAbsolutePath();
+        String logDir = "/sdcard/mlperf_results/" + logDirBase + bm.getId();
+        File appDir = new File(logDir);
+        appDir.mkdirs();
+        Log.d(TAG,logDirBase + " file path: " + logDir);
 
         startingList[counter] = new StartData(bm.getId(), logDir, runMode, batch);
       }


### PR DESCRIPTION
On few android 11 based phones, the log directory
generated by loadgen is not accessible from adb shell.
So, there is no way to pull the results out. Hence, changing
the log directory to /sdcard/mlperf_results instead of the
previous app's context external directory.