### PR TITLE
Update build instruction and add missing instructions for installing and using the app

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -65,13 +65,14 @@ pip3 install numpy absl-py
 ```
 
 ## Option 1 - Building Manually
-The app can be built and installed with the following commands:
+The app can be built and installed with the following commands 
+(execute from root directory `mobile_app_open`):
 
 ```bash
-bazel build -c opt //java/org/mlperf/inference:mlperf_app
+bazel build -c opt //android/java/org/mlperf/inference:mlperf_app
 
 # Install the app with the command:
-adb install -r bazel-bin/java/org/mlperf/inference/mlperf_app.apk
+adb install -r bazel-bin/android/java/org/mlperf/inference/mlperf_app.apk
 ```
 
 
@@ -111,7 +112,7 @@ Make sure you follow the Getting Started steps listed above to set up your SDK/N
 5. File > Import Bazel Project and follow the instructions
 6. Run > Edit Configurations...
 7. Click the + button in the upper-left corner and select 'Bazel Command' from the list
-8. Click the + button in the 'Target expression' box and enter ```//java/org/mlperf/inference:mlperf_app```
+8. Click the + button in the 'Target expression' box and enter ```//android/java/org/mlperf/inference:mlperf_app```
 9. Select 'Build' from the 'Bazel command' dropdown
 10. Enter the following into the 'Bazel flags' box:
 ```
@@ -206,7 +207,7 @@ local_repository(
 )
 ```
 Modify the Makefile to change release-app to use your backend when
-building with --//java/org/mlperf/inference:with_vendor="1"
+building with --//android/java/org/mlperf/inference:with_vendor="1"
 substituting your backend name for vendor.
 
 ## FAQ

--- a/android/README.md
+++ b/android/README.md
@@ -122,8 +122,7 @@ Make sure you follow the Getting Started steps listed above to set up your SDK/N
 ```
 11. Run > Run 'inference:mlperf_app'
 
-Please see [these instructions](prebuilt/README.md) for installing and using the
-app.
+Please see [these instructions](docs/guides/installation.md) for installing and using the app.
 
 ## Adding a new Backend
 

--- a/android/docs/guides/installation.md
+++ b/android/docs/guides/installation.md
@@ -1,0 +1,91 @@
+## Getting Started
+
+Until the app is available in the
+[Play Store](https://play.google.com/store?hl=en_US), it requires manual
+installation from a host machine. Due to restrictions in dataset redistribution,
+some amount of manual retrieval, processing and packaging is required to use
+certain task datasets for accuracy evaluation. We're actively investigating how
+we can bundle the necessary datasets directly in the app.
+
+If you're primarily interested in testing inference latency, skip directly to
+the [App Execution](#app-execution) section. The app can run MLPerf latency
+measurements without the need for full dataset installation.
+
+### Dataset installation
+
+A tasks-specific dataset is required required for measuring accuracy.
+
+This currently requires some manual work to prepare and distribute the relevant
+datasets. Note that the full datasets can be extremely large; a subset of the
+full dataset can be prepared to give a useful proxy for task-specific accuracy.
+When prepared, each task directory should be pushed to
+`/sdcard/mlperf_datasets/...`.
+
+#### Imagenet (Classification)
+
+The app evaluates Image Classification via MobileNet V1 (float & quantized),
+using any subset of images used in the
+[ILSVRC 2012 image classification task](http://www.image-net.org/download-images/).
+
+To download the 2012 dataset, you will need to do the following:
+
+*   Open the
+    [ImageNet downloads link](http://www.image-net.org/download-images),
+    creating an ImageNet account if you have not done so already.
+*   Navigate to the 2012 downloads page under the **`Download links to ILSVRC
+    image data`** section.
+*   Download the **`Validation images (all tasks)`** archive.
+*   Create a staging directory for the dataset, call it
+    `${WORKING_DIR}/imagenet`.
+*   From the downloaded archive, extract the images into a
+    `${WORKING_DIR}/imagenet/img` directory.
+
+The full set of validation images is quite large, over 6GB. This can take an
+extremely long time to process, so it is *highly* recommended that you use a
+smaller subset of images. We recommend leaving ~300 images in
+`${WORKING_DIR}/imagenet/img`. The resulting folder contents should appear like:
+
+*   `imagenet/img` : `folder` \
+    Contains the set of images to evaluate over. This could be any subset of the
+    ILSVRC 2012 evaluation dataset (strongly recommend using <300 for test/dev
+    purposes).
+
+The classification model and validation label files are already in the app, for
+convenience. Once the data has been prepared, push the resulting `imagenet`
+folder to `/sdcard/mlperf_datasets/imagenet`.
+
+#### Coco (Detection)
+
+The app evaluates Object Detection using any subset of images used in
+[COCO 2017 dataset](http://cocodataset.org/#download).
+
+To prepare the dataset for object detection you need to do the following:
+
+*   Download the 2017 Val images from above website.
+*   Extract the images to `${WORKING_DIR}/coco/img` directory.
+
+The resulting folder contents should appear like:
+
+*   `coco/img` : `folder` \
+    Contains the set of images to evaluate over. This could be any subset of the
+    COCO 2017 evaluation dataset.
+
+Once the data has been prepared push the resulting `coco` folder to
+`/sdcard/mlperf_datasets/coco`.
+
+## <a name="app-execution"></a> App Execution
+
+After the app has been installed, and the optional dataset(s), simply open
+**`MLPerf Mobile`** from the Android launcher. The app UI allows selection of
+supported tasks, and execution of the supported models (float/quantized) for
+each task. If a dataset has been pushed for the task, the task-specific accuracy
+will be measured, otherwise it will only report latency results.
+
+The user can also configure runtime execution with the following options:
+
+*   TensorFlow Lite Accelerator:
+    *   None - Default (CPU) backend for TensorFlow Lite
+    *   GPU - Enables use of the GPU (via OpenGL/OpennCL)
+    *   NNAPI - Enables use of
+        [Android's NN API](https://developer.android.com/ndk/guides/neuralnetworks)
+*   Number of threads - for CPU execution

--- a/android/docs/guides/installation.md
+++ b/android/docs/guides/installation.md
@@ -1,58 +1,46 @@
 ## Getting Started
 
-Until the app is available in the
-[Play Store](https://play.google.com/store?hl=en_US), it requires manual
-installation from a host machine. Due to restrictions in dataset redistribution,
-some amount of manual retrieval, processing and packaging is required to use
-certain task datasets for accuracy evaluation. We're actively investigating how
-we can bundle the necessary datasets directly in the app.
+Due to restrictions in dataset redistribution, some amount of manual retrieval, processing
+and packaging is required to use certain task datasets for accuracy evaluation.
 
 If you're primarily interested in testing inference latency, skip directly to
-the [App Execution](#app-execution) section. The app can run MLPerf latency
-measurements without the need for full dataset installation.
+the [App Execution](#app-execution) section. The app can run MLPerf latency measurements
+without the need for full dataset installation.
 
 ### Dataset installation
 
-A tasks-specific dataset is required required for measuring accuracy.
+A tasks-specific dataset is required for measuring accuracy.
 
-This currently requires some manual work to prepare and distribute the relevant
-datasets. Note that the full datasets can be extremely large; a subset of the
-full dataset can be prepared to give a useful proxy for task-specific accuracy.
-When prepared, each task directory should be pushed to
-`/sdcard/mlperf_datasets/...`.
+This currently requires some manual work to prepare and distribute the relevant datasets.
+Note that the full datasets can be extremely large; a subset of the full dataset can be
+prepared to give a useful proxy for task-specific accuracy. When prepared, each task
+directory should be pushed to `/sdcard/mlperf_datasets/...`.
 
 #### Imagenet (Classification)
 
-The app evaluates Image Classification via MobileNet V1 (float & quantized),
-using any subset of images used in the
+The app evaluates Image Classification using any subset of images used in the
 [ILSVRC 2012 image classification task](http://www.image-net.org/download-images/).
 
 To download the 2012 dataset, you will need to do the following:
 
-*   Open the
-    [ImageNet downloads link](http://www.image-net.org/download-images),
-    creating an ImageNet account if you have not done so already.
-*   Navigate to the 2012 downloads page under the **`Download links to ILSVRC
-    image data`** section.
-*   Download the **`Validation images (all tasks)`** archive.
-*   Create a staging directory for the dataset, call it
-    `${WORKING_DIR}/imagenet`.
-*   From the downloaded archive, extract the images into a
-    `${WORKING_DIR}/imagenet/img` directory.
+* Open the [ImageNet downloads link](http://www.image-net.org/download-images), creating
+  an ImageNet account if you have not done so already.
+* Navigate to the 2012 downloads page under the **`Download links to ILSVRC image data`**
+  section.
+* Download the **`Validation images (all tasks)`** archive.
+* Create a staging directory for the dataset, call it `${WORKING_DIR}/imagenet`.
+* From the downloaded archive, extract the images into a `${WORKING_DIR}/imagenet/img`
+  directory.
 
-The full set of validation images is quite large, over 6GB. This can take an
-extremely long time to process, so it is *highly* recommended that you use a
-smaller subset of images. We recommend leaving ~300 images in
-`${WORKING_DIR}/imagenet/img`. The resulting folder contents should appear like:
+The full set of validation images is quite large, over 6GB. This can take an extremely
+long time to process. The resulting folder contents should appear like:
 
-*   `imagenet/img` : `folder` \
-    Contains the set of images to evaluate over. This could be any subset of the
-    ILSVRC 2012 evaluation dataset (strongly recommend using <300 for test/dev
-    purposes).
+* `imagenet/img` : `folder` \
+  Contains the set of images to evaluate over. This could be any subset of the ILSVRC 2012
+  evaluation dataset.
 
-The classification model and validation label files are already in the app, for
-convenience. Once the data has been prepared, push the resulting `imagenet`
-folder to `/sdcard/mlperf_datasets/imagenet`.
+Once the data has been prepared, push the resulting `imagenet` folder
+to `/sdcard/mlperf_datasets/imagenet`.
 
 #### Coco (Detection)
 
@@ -61,14 +49,14 @@ The app evaluates Object Detection using any subset of images used in
 
 To prepare the dataset for object detection you need to do the following:
 
-*   Download the 2017 Val images from above website.
-*   Extract the images to `${WORKING_DIR}/coco/img` directory.
+* Download the 2017 Val images from above website.
+* Extract the images to `${WORKING_DIR}/coco/img` directory.
 
 The resulting folder contents should appear like:
 
-*   `coco/img` : `folder` \
-    Contains the set of images to evaluate over. This could be any subset of the
-    COCO 2017 evaluation dataset.
+* `coco/img` : `folder` \
+  Contains the set of images to evaluate over. This could be any subset of the COCO 2017
+  evaluation dataset.
 
 Once the data has been prepared push the resulting `coco` folder to
 `/sdcard/mlperf_datasets/coco`.
@@ -76,16 +64,8 @@ Once the data has been prepared push the resulting `coco` folder to
 ## <a name="app-execution"></a> App Execution
 
 After the app has been installed, and the optional dataset(s), simply open
-**`MLPerf Mobile`** from the Android launcher. The app UI allows selection of
-supported tasks, and execution of the supported models (float/quantized) for
-each task. If a dataset has been pushed for the task, the task-specific accuracy
-will be measured, otherwise it will only report latency results.
+**`MLPerf Mobile`** from the Android launcher. The app UI allows selection of supported
+tasks, and execution of the supported models (float/quantized) for each task.
 
-The user can also configure runtime execution with the following options:
-
-*   TensorFlow Lite Accelerator:
-    *   None - Default (CPU) backend for TensorFlow Lite
-    *   GPU - Enables use of the GPU (via OpenGL/OpennCL)
-    *   NNAPI - Enables use of
-        [Android's NN API](https://developer.android.com/ndk/guides/neuralnetworks)
-*   Number of threads - for CPU execution
+If **`Submission mode`** is enabled, the task-specific accuracy will be measured, otherwise it
+will only report latency results.

--- a/android/docs/guides/installation.md
+++ b/android/docs/guides/installation.md
@@ -16,50 +16,8 @@ Note that the full datasets can be extremely large; a subset of the full dataset
 prepared to give a useful proxy for task-specific accuracy. When prepared, each task
 directory should be pushed to `/sdcard/mlperf_datasets/...`.
 
-#### Imagenet (Classification)
-
-The app evaluates Image Classification using any subset of images used in the
-[ILSVRC 2012 image classification task](http://www.image-net.org/download-images/).
-
-To download the 2012 dataset, you will need to do the following:
-
-* Open the [ImageNet downloads link](http://www.image-net.org/download-images), creating
-  an ImageNet account if you have not done so already.
-* Navigate to the 2012 downloads page under the **`Download links to ILSVRC image data`**
-  section.
-* Download the **`Validation images (all tasks)`** archive.
-* Create a staging directory for the dataset, call it `${WORKING_DIR}/imagenet`.
-* From the downloaded archive, extract the images into a `${WORKING_DIR}/imagenet/img`
-  directory.
-
-The full set of validation images is quite large, over 6GB. This can take an extremely
-long time to process. The resulting folder contents should appear like:
-
-* `imagenet/img` : `folder` \
-  Contains the set of images to evaluate over. This could be any subset of the ILSVRC 2012
-  evaluation dataset.
-
-Once the data has been prepared, push the resulting `imagenet` folder
-to `/sdcard/mlperf_datasets/imagenet`.
-
-#### Coco (Detection)
-
-The app evaluates Object Detection using any subset of images used in
-[COCO 2017 dataset](http://cocodataset.org/#download).
-
-To prepare the dataset for object detection you need to do the following:
-
-* Download the 2017 Val images from above website.
-* Extract the images to `${WORKING_DIR}/coco/img` directory.
-
-The resulting folder contents should appear like:
-
-* `coco/img` : `folder` \
-  Contains the set of images to evaluate over. This could be any subset of the COCO 2017
-  evaluation dataset.
-
-Once the data has been prepared push the resulting `coco` folder to
-`/sdcard/mlperf_datasets/coco`.
+You can follow [this guide](https://github.com/mlcommons/mobile_app_open/blob/master/android/cpp/datasets/README.md) 
+to download the datasets.
 
 ## <a name="app-execution"></a> App Execution
 

--- a/android/docs/guides/installation.md
+++ b/android/docs/guides/installation.md
@@ -69,3 +69,4 @@ tasks, and execution of the supported models (float/quantized) for each task.
 
 If **`Submission mode`** is enabled, the task-specific accuracy will be measured, otherwise it
 will only report latency results.
+


### PR DESCRIPTION
Replace `//java/org/mlperf/` with `//android/java/org/mlperf/` and add missing instructions for installing and using the app.