### PR TITLE
Make cache and output files on Android accessible for user.

### DIFF
--- a/flutter/documentation/custom-tasks.md
+++ b/flutter/documentation/custom-tasks.md
@@ -19,10 +19,10 @@ Add new paths to the file `tasks.pbtxt` in following format:
 See [Resources in the tasks.pbtxt](#resources-in-the-taskspbtxt) block
 for details on different ways you can specify resources.
 
-After adding new option into the `benchmarkCponfigurations.json` file
+After adding new option into the `benchmarksConfigurations.json` file
 run application and open setting screen.  
 Tap on `Benchmarks configuration path` option
-and choose added item. Current chosen path highlited blue.
+and choose added item. Current chosen path highlighted blue.
 
 # Resources in the tasks.pbtxt
 
@@ -41,9 +41,9 @@ Location of the external resources directory is platform dependent.
 # Using external resources on an iPhone
 
 On iOS an application resource folder can be found in `On My iPhone` -> `<app name>`.
-The `external resources` folder corresponds to the `mlperf_datasets` folder in path specified in `tasks.pbtxt`.
+The `external_resources` folder corresponds to the `mlperf_datasets` folder in path specified in `tasks.pbtxt`.
 So, if you have `/sdcard/mlperf_datasets/some/folders/test.txt` path in your config file,
-then the path on your iPhone would be: `MLPerf/external resources/some/folders/test.txt`.
+then the path on your iPhone would be: `MLPerf/external_resources/some/folders/test.txt`.
 
 Note, that iPhone's `Files` app has issues with moving folders with big number of files into application folders.
 So if you have an archive with big dataset and want to place it in the app resources folder,
@@ -55,3 +55,13 @@ Also note, that sometimes iPhone's `Files` app may prevent you from copying file
 from some external file managers and cloud storage clients.
 Instead of copying your file using `Files`, you can use Share button in your external app and choose "Save to Files".
 This method doesn't have restrictions on file extension.
+
+# Using external resources on an Android
+On Android the resource folder is located at `/Android/data/org.mlcommons.android.mlperfbench/files`.
+On Android 11, the folder `/Android/data/` is inaccessible using the default File Manager app. 
+It stills accessible through 3rd party File Manager apps, though. 
+Or using a File Manager on a desktop computer and access the files via USB also works.
+
+So, if you have `/sdcard/mlperf_datasets/some/folders/test.txt` path in your config file,
+then the path on your Android phone would be:
+`/Android/data/org.mlcommons.android.mlperfbench/files/external_resources/some/folders/test.txt`.

--- a/flutter/ios/Podfile.lock
+++ b/flutter/ios/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
-  - path_provider (0.0.1):
+  - path_provider_ios (0.0.1):
     - Flutter
   - share (0.0.1):
     - Flutter
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider (from `.symlinks/plugins/path_provider/ios`)
+  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - share (from `.symlinks/plugins/share/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
@@ -40,8 +40,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
-  path_provider:
-    :path: ".symlinks/plugins/path_provider/ios"
+  path_provider_ios:
+    :path: ".symlinks/plugins/path_provider_ios/ios"
   share:
     :path: ".symlinks/plugins/share/ios"
   share_plus:
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   integration_test: 7db6d89f336f671dcbc7563ee27a5b08f6f8aee1
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
-  path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
+  path_provider_ios: 7d7ce634493af4477d156294792024ec3485acd5
   share: 0b2c3e82132f5888bccca3351c504d0003b3b410
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d

--- a/flutter/lib/benchmark/resource_manager.dart
+++ b/flutter/lib/benchmark/resource_manager.dart
@@ -108,9 +108,23 @@ class ResourceManager {
   }
 
   Future<void> initSystemPaths() async {
-    applicationDirectory = (await getApplicationDocumentsDirectory()).path;
-    loadedResourcesDir = '$applicationDirectory/loaded resources';
-    externalResourcesDir = '$applicationDirectory/external resources';
+    // applicationDirectory should be visible to user
+    Directory? dir;
+    if (Platform.isIOS) {
+      dir = await getApplicationDocumentsDirectory();
+    } else if (Platform.isAndroid) {
+      dir = await getExternalStorageDirectory();
+    } else if (Platform.isWindows) {
+      dir = await getDownloadsDirectory();
+    }
+    if (dir != null) {
+      applicationDirectory = dir.path;
+    } else {
+      applicationDirectory = (await getApplicationDocumentsDirectory()).path;
+    }
+
+    loadedResourcesDir = '$applicationDirectory/loaded_resources';
+    externalResourcesDir = '$applicationDirectory/external_resources';
     _tmpDirectory = (await getTemporaryDirectory()).path;
     _jsonResultPath = '$applicationDirectory/result.json';
 

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -357,7 +357,21 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.7"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.7"
   path_provider_linux:
     dependency: transitive
     description:
@@ -756,5 +770,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"


### PR DESCRIPTION
Closes #149.
Part of #125.