### PR TITLE
Standardize accuracy result display.

### DIFF
--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -56,6 +56,8 @@ class Benchmark {
   /// 'SingleStream' or 'Offline'.
   String get scenario => modelConfig.scenario;
 
+  BenchmarkTypeEnum get type => _typeFromCode();
+
   SvgPicture get icon => BENCHMARK_ICONS[scenario]?[code] ?? Icons.logo;
 
   SvgPicture get iconWhite =>
@@ -63,6 +65,21 @@ class Benchmark {
 
   @override
   String toString() => 'Benchmark:$id';
+
+  BenchmarkTypeEnum _typeFromCode() {
+    switch (code) {
+      case 'IC':
+        return BenchmarkTypeEnum.imageClassification;
+      case 'OD':
+        return BenchmarkTypeEnum.objectDetection;
+      case 'IS':
+        return BenchmarkTypeEnum.imageSegmentation;
+      case 'LU':
+        return BenchmarkTypeEnum.languageUnderstanding;
+      default:
+        return BenchmarkTypeEnum.unknown;
+    }
+  }
 }
 
 class MiddleInterface {
@@ -137,6 +154,14 @@ class MiddleInterface {
     result.sort();
     return result.where((element) => element.isNotEmpty).toList();
   }
+}
+
+enum BenchmarkTypeEnum {
+  unknown,
+  imageClassification,
+  objectDetection,
+  imageSegmentation,
+  languageUnderstanding,
 }
 
 enum BenchmarkStateEnum {

--- a/flutter/lib/ui/result_screen.dart
+++ b/flutter/lib/ui/result_screen.dart
@@ -59,6 +59,26 @@ class _ResultScreenState extends State<ResultScreen>
     super.dispose();
   }
 
+  String _getFormattedAccuracyValue(Benchmark benchmark) {
+    final accuracy = benchmark.accuracy;
+    if (accuracy == null) return 'N/A';
+    final numeric = _getNumericAccuracy(accuracy);
+    switch (benchmark.type) {
+      // if the benchmark type is unknown, just show the original string
+      // so we know that this need to be fixed
+      case BenchmarkTypeEnum.unknown:
+        return _getAccuracyValue(benchmark.accuracy);
+      case BenchmarkTypeEnum.imageClassification:
+        return (numeric * 100).toStringAsFixed(2);
+      case BenchmarkTypeEnum.objectDetection:
+        return (numeric * 100).toStringAsFixed(2);
+      case BenchmarkTypeEnum.imageSegmentation:
+        return (numeric * 100).toStringAsFixed(2);
+      case BenchmarkTypeEnum.languageUnderstanding:
+        return numeric.toStringAsFixed(2);
+    }
+  }
+
   double _getNumericAccuracy(String accuracy) {
     final percentPattern = '%';
 
@@ -225,7 +245,7 @@ class _ResultScreenState extends State<ResultScreen>
                 Text(
                   _screenMode == _ScreenMode.performance
                       ? benchmark.score?.toStringAsFixed(2) ?? 'N/A'
-                      : _getAccuracyValue(benchmark.accuracy),
+                      : _getFormattedAccuracyValue(benchmark),
                   style: TextStyle(
                       fontSize: 32.0,
                       color: Colors.white,


### PR DESCRIPTION
Closes #169 

This is how it looks in overview:

![IMG_7265](https://user-images.githubusercontent.com/85728587/147657526-9177e64d-04ba-4884-9d17-ef7f42c6e600.jpeg)

Detailed results still show the original string:

![detailed](https://user-images.githubusercontent.com/85728587/147659198-dde5ddcc-0218-4504-997f-c54fe45e89fe.jpeg)

