### PR TITLE
#30 samsungbackend close workaround

### DIFF
--- a/android/cpp/backends/external.cc
+++ b/android/cpp/backends/external.cc
@@ -79,7 +79,7 @@ BackendFunctions::BackendFunctions(const std::string& lib_path) {
     }
     handle = tflite::SharedLibrary::LoadLibrary(wide_lib_path.c_str());
 #else
-    handle = tflite::SharedLibrary::LoadLibrary(lib_path.c_str());
+    handle = dlopen(lib_path.c_str(), RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
 #endif
     if (handle == nullptr) {
       LOG(ERROR) << "Unable to load: " << lib_path << ": "

--- a/android/cpp/backends/external.h
+++ b/android/cpp/backends/external.h
@@ -31,7 +31,7 @@ struct BackendFunctions {
   BackendFunctions(const std::string& lib_path);
 
   ~BackendFunctions() {
-    if (handle) {
+    if (false) {
       tflite::SharedLibrary::UnLoadLibrary(handle);
     }
   }

--- a/android/cpp/backends/external.h
+++ b/android/cpp/backends/external.h
@@ -31,7 +31,7 @@ struct BackendFunctions {
   BackendFunctions(const std::string& lib_path);
 
   ~BackendFunctions() {
-    if (false) {
+    if (handle) {
       tflite::SharedLibrary::UnLoadLibrary(handle);
     }
   }

--- a/android/java/org/mlperf/inference/RunMLPerfWorker.java
+++ b/android/java/org/mlperf/inference/RunMLPerfWorker.java
@@ -175,10 +175,8 @@ public final class RunMLPerfWorker implements Handler.Callback {
       result.setDuration(driverWrapper.getDurationMs());
       result.setMode(data.mode);
       callback.onBenchmarkFinished(result);
+      driverWrapper.close();
 
-      if (!backendName.contains("samsung")) {
-        driverWrapper.close();
-      }
     } catch (Exception e) {
       Log.e(TAG, "Running \"" + modelName + "\" failed with error: " + e.getMessage());
       Log.e(TAG, Log.getStackTraceString(e));

--- a/mobile_back_samsung/cpp/eden_mlperf_c_backend/jni/edenai.cc
+++ b/mobile_back_samsung/cpp/eden_mlperf_c_backend/jni/edenai.cc
@@ -1053,7 +1053,7 @@ void mlperf_backend_clear(mlperf_backend_ptr_t backend_ptr) {
   delete samsung_backend;
 }
 
-static Backend *ss_backend;
+static Backend* ss_backend;
 
 // Create a new backend and return the pointer to it.
 mlperf_backend_ptr_t mlperf_backend_create(

--- a/mobile_back_samsung/cpp/eden_mlperf_c_backend/jni/edenai.cc
+++ b/mobile_back_samsung/cpp/eden_mlperf_c_backend/jni/edenai.cc
@@ -1050,15 +1050,17 @@ void mlperf_backend_clear(mlperf_backend_ptr_t backend_ptr) {
   EdenAI::jni_CloseModel();
   EdenAI::jni_Shutdown();
   libeden_nn_on_direct = nullptr;
+  delete samsung_backend;
 }
 
-Backend ss_backend;
+static Backend *ss_backend;
 
 // Create a new backend and return the pointer to it.
 mlperf_backend_ptr_t mlperf_backend_create(
     const char* model_path, mlperf_backend_configuration_t* configs,
     const char* native_lib_path) {
-  Backend* samsung_backend = &ss_backend;
+  ss_backend = new Backend();
+  Backend* samsung_backend = ss_backend;
   if (samsung_backend->created) {
     mlperf_backend_clear(samsung_backend);
   }


### PR DESCRIPTION
driverWrapper.close() function call ends up calling external.cc files tflite::UnloadLibrary(handle) function which is essentially a dlclose() call on libsamsungbackend.so file. Moving the workaround of commenting driverWrapper.close() to deeper level is more specific to the issue. Also allocated memory dynamically for the backend object.