### PR TITLE
Add new API to return the accelerator name.

### DIFF
--- a/flutter/cpp/backend.h
+++ b/flutter/cpp/backend.h
@@ -38,6 +38,9 @@ class Backend {
   // A human-readable string for logging purposes.
   virtual const std::string& Name() const = 0;
 
+  // Accelerator name.
+  virtual const std::string& AcceleratorName() const = 0;
+
   // Run inference for a sample. Inputs is already set by SetInputs.
   virtual void IssueQuery() = 0;
 

--- a/flutter/cpp/backends/external.cc
+++ b/flutter/cpp/backends/external.cc
@@ -102,6 +102,8 @@ BackendFunctions::BackendFunctions(const std::string& lib_path) {
   create =
       reinterpret_cast<decltype(create)>(GetSymbol("mlperf_backend_create"));
   name = reinterpret_cast<decltype(name)>(GetSymbol("mlperf_backend_name"));
+  accelerator_name = reinterpret_cast<decltype(accelerator_name)>(
+      GetSymbol("mlperf_backend_accelerator_name"));
   destroy =
       reinterpret_cast<decltype(destroy)>(GetSymbol("mlperf_backend_delete"));
 
@@ -170,6 +172,9 @@ ExternalBackend::ExternalBackend(const std::string& model_file_path,
 
   // Get the backend name.
   name_ = backend_functions_.name(backend_ptr_);
+
+  // Get the accelerator name.
+  accelerator_name_ = backend_functions_.accelerator_name(backend_ptr_);
 }
 
 }  // namespace mobile

--- a/flutter/cpp/backends/external.h
+++ b/flutter/cpp/backends/external.h
@@ -42,6 +42,8 @@ struct BackendFunctions {
       const char*, mlperf_backend_configuration_t*, const char*)>::type;
   using BackendNamePtr =
       std::add_pointer<const char*(mlperf_backend_ptr_t)>::type;
+  using AcceleratorNamePtr =
+      std::add_pointer<const char*(mlperf_backend_ptr_t)>::type;
   using BackendDeletePtr = std::add_pointer<void(mlperf_backend_ptr_t)>::type;
   using IssueQueryPtr =
       std::add_pointer<mlperf_status_t(mlperf_backend_ptr_t)>::type;
@@ -68,6 +70,7 @@ struct BackendFunctions {
   BackendMatchesPtr match{nullptr};
   BackendCreatePtr create{nullptr};
   BackendNamePtr name{nullptr};
+  AcceleratorNamePtr accelerator_name{nullptr};
   BackendDeletePtr destroy{nullptr};
 
   IssueQueryPtr issue_query{nullptr};
@@ -139,6 +142,11 @@ class ExternalBackend : public Backend {
   // A human-readable string for logging purposes.
   const std::string& Name() const override { return name_; }
 
+  // Accelerator name
+  const std::string& AcceleratorName() const override {
+    return accelerator_name_;
+  }
+
   // Run inference for a sample.
   void IssueQuery() override {
     if (backend_functions_.issue_query(backend_ptr_) != MLPERF_SUCCESS) {
@@ -198,6 +206,7 @@ class ExternalBackend : public Backend {
 
  private:
   std::string name_ = "External";
+  std::string accelerator_name_ = "Accelerator";
   std::string settings_;
   DataFormat input_format_;
   DataFormat output_format_;

--- a/flutter/cpp/c/backend_c.h
+++ b/flutter/cpp/c/backend_c.h
@@ -36,6 +36,9 @@ mlperf_backend_ptr_t mlperf_backend_create(
 // Vendor name who create this backend.
 const char* mlperf_backend_vendor_name(mlperf_backend_ptr_t backend_ptr);
 
+// Return the name of the accelerator.
+const char* mlperf_backend_accelerator_name(mlperf_backend_ptr_t backend_ptr);
+
 // Return the name of this backend.
 const char* mlperf_backend_name(mlperf_backend_ptr_t backend_ptr);
 

--- a/flutter/cpp/c/dll_export.def
+++ b/flutter/cpp/c/dll_export.def
@@ -2,6 +2,7 @@ EXPORTS
     mlperf_backend_matches_hardware
     mlperf_backend_create
     mlperf_backend_vendor_name
+    mlperf_backend_accelerator_name
     mlperf_backend_name
     mlperf_backend_delete
     mlperf_backend_issue_query

--- a/flutter/cpp/flutter/main.cc
+++ b/flutter/cpp/flutter/main.cc
@@ -92,6 +92,7 @@ extern "C" struct dart_ffi_run_benchmark_out* dart_ffi_run_benchmark(
   li;
 
   char* backend_name = strdup(backend->Name().c_str());
+  char* accelerator_name = strdup(backend->AcceleratorName().c_str());
 
   ::std::unique_ptr<::mlperf::mobile::Dataset> dataset;
   switch (in->dataset_type) {
@@ -155,6 +156,7 @@ extern "C" struct dart_ffi_run_benchmark_out* dart_ffi_run_benchmark(
   out->num_samples = driver.GetNumSamples();
   out->duration_ms = driver.GetDurationMs();
   out->backend_name = backend_name;
+  out->accelerator_name = accelerator_name;
   li;
 
   return out;
@@ -163,5 +165,6 @@ extern "C" struct dart_ffi_run_benchmark_out* dart_ffi_run_benchmark(
 void dart_ffi_run_benchmark_free(struct dart_ffi_run_benchmark_out* out) {
   free(out->accuracy);
   free(out->backend_name);
+  free(out->accelerator_name);
   delete out;
 }

--- a/flutter/cpp/flutter/main.h
+++ b/flutter/cpp/flutter/main.h
@@ -39,6 +39,7 @@ struct dart_ffi_run_benchmark_out {
   int32_t num_samples;
   float duration_ms;
   char *backend_name;
+  char *accelerator_name;
 };
 
 struct dart_ffi_run_benchmark_out *dart_ffi_run_benchmark(

--- a/flutter/lib/backend/bridge/ffi_run.dart
+++ b/flutter/lib/backend/bridge/ffi_run.dart
@@ -83,6 +83,7 @@ class _RunOut extends Struct {
   @Float()
   external double duration_ms;
   external Pointer<Utf8> backend_name;
+  external Pointer<Utf8> accelerator_name;
 }
 
 const _runName = 'dart_ffi_run_benchmark';
@@ -117,6 +118,7 @@ RunResult runBenchmark(RunSettings rs) {
     numSamples: runOut.ref.num_samples,
     durationMs: runOut.ref.duration_ms,
     backendName: runOut.ref.backend_name.toDartString(),
+    acceleratorName: runOut.ref.accelerator_name.toDartString(),
   );
 
   _free(runOut);

--- a/flutter/lib/backend/bridge/run_result.dart
+++ b/flutter/lib/backend/bridge/run_result.dart
@@ -4,12 +4,14 @@ class RunResult {
   final double durationMs;
   final double throughput;
   final String backendName;
+  final String acceleratorName;
 
   RunResult({
     required this.accuracy,
     required this.numSamples,
     required this.durationMs,
     required this.backendName,
+    required this.acceleratorName,
     required this.throughput,
   });
 

--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -15,6 +15,7 @@ class BenchmarkResult {
   final double throughput;
   final String accuracy;
   final String backendName;
+  final String acceleratorName;
   final int batchSize;
   final int threadsNumber;
 
@@ -22,6 +23,7 @@ class BenchmarkResult {
       {required this.throughput,
       required String accuracy,
       required this.backendName,
+      required this.acceleratorName,
       required this.batchSize,
       required this.threadsNumber})
       : accuracy = _replaceAccuracy(accuracy);
@@ -62,6 +64,7 @@ class BenchmarkResult {
   static const _tagThroughput = 'throughput';
   static const _tagAccuracy = 'accuracy';
   static const _tagBackendName = 'backend_name';
+  static const _tagAcceleratorName = 'accelerator_name';
   static const _tagBatchSize = 'batch_size';
   static const _tagThreadsNumber = 'threads_number';
 
@@ -71,6 +74,7 @@ class BenchmarkResult {
         throughput: json[_tagThroughput] as double,
         accuracy: json[_tagAccuracy] as String,
         backendName: json[_tagBackendName] as String,
+        acceleratorName: json[_tagAcceleratorName] as String,
         batchSize: json[_tagBatchSize] as int,
         threadsNumber: json[_tagThreadsNumber] as int);
   }
@@ -79,6 +83,7 @@ class BenchmarkResult {
         _tagThroughput: throughput,
         _tagAccuracy: accuracy,
         _tagBackendName: backendName,
+        _tagAcceleratorName: acceleratorName,
         _tagBatchSize: batchSize,
         _tagThreadsNumber: threadsNumber,
       };

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -258,6 +258,7 @@ class BenchmarkState extends ChangeNotifier {
           throughput: performanceResult.result.throughput,
           accuracy: performanceResult.result.accuracy,
           backendName: performanceResult.result.backendName,
+          acceleratorName: performanceResult.result.acceleratorName,
           batchSize: benchmark.config.batchSize,
           threadsNumber: benchmark.config.threadsNumber);
       exportResults.add(ExportResult.fromRunInfo(performanceResult));
@@ -274,6 +275,7 @@ class BenchmarkState extends ChangeNotifier {
           throughput: accuracyResult.result.throughput,
           accuracy: accuracyResult.result.accuracy,
           backendName: accuracyResult.result.backendName,
+          acceleratorName: accuracyResult.result.acceleratorName,
           batchSize: benchmark.config.batchSize,
           threadsNumber: benchmark.config.threadsNumber);
       exportResults.add(ExportResult.fromRunInfo(accuracyResult));

--- a/flutter/lib/data/export_result.dart
+++ b/flutter/lib/data/export_result.dart
@@ -15,9 +15,8 @@ class ExportResult {
   static const String _tagBatchSize = 'batch_size';
   static const String _tagMode = 'mode';
   static const String _tagDatetime = 'datetime';
-  // format of results.json should be stable,
-  // so we keep 'backendDescription' tag here
-  static const String _tagBackendName = 'backendDescription';
+  static const String _tagBackendName = 'backendName';
+  static const String _tagAcceleratorName = 'acceleratorName';
 
   final String id;
   final String throughput;
@@ -32,6 +31,7 @@ class ExportResult {
   final String mode;
   final String datetime;
   final String backendName;
+  final String acceleratorName;
 
   ExportResult(
       {required this.id,
@@ -45,7 +45,8 @@ class ExportResult {
       required this.batchSize,
       required this.mode,
       required this.datetime,
-      required this.backendName});
+      required this.backendName,
+      required this.acceleratorName});
 
   ExportResult.fromRunInfo(RunInfo info)
       : this(
@@ -64,7 +65,8 @@ class ExportResult {
             batchSize: info.settings.batch_size,
             mode: info.runMode.getResultModeString(),
             datetime: DateTime.now().toIso8601String(),
-            backendName: info.result.backendName);
+            backendName: info.result.backendName,
+            acceleratorName: info.result.acceleratorName);
 
   ExportResult.fromJson(Map<String, dynamic> json)
       : this(
@@ -79,7 +81,8 @@ class ExportResult {
             batchSize: json[_tagBatchSize] as int,
             mode: json[_tagMode] as String,
             datetime: json[_tagDatetime] as String,
-            backendName: json[_tagBackendName] as String);
+            backendName: json[_tagBackendName] as String,
+            acceleratorName: json[_tagAcceleratorName] as String);
 
   Map<String, dynamic> toJson() => {
         _tagId: id,
@@ -97,6 +100,7 @@ class ExportResult {
         _tagMode: mode,
         _tagDatetime: datetime,
         _tagBackendName: backendName,
+        _tagAcceleratorName: acceleratorName,
       };
 }
 

--- a/flutter/lib/data/json_generator_main.dart
+++ b/flutter/lib/data/json_generator_main.dart
@@ -21,6 +21,7 @@ Future<void> main() async {
     accuracy: 'N/A',
     throughput: '123.45',
     backendName: 'backend',
+    acceleratorName: 'accelerator',
     minDuration: '10',
     duration: '123.456',
     minSamples: '8',

--- a/flutter/lib/ui/result_screen.dart
+++ b/flutter/lib/ui/result_screen.dart
@@ -84,6 +84,8 @@ class _ResultScreenState extends State<ResultScreen>
         continue;
       }
       final backendName = benchmark.performanceModeResult?.backendName ?? '';
+      final acceleratorName =
+          benchmark.performanceModeResult?.acceleratorName ?? '';
 
       var rowChildren = <Widget>[];
       rowChildren.add(Row(
@@ -92,7 +94,7 @@ class _ResultScreenState extends State<ResultScreen>
         children: [
           Padding(
               padding: const EdgeInsets.only(bottom: 5),
-              child: Text(backendName)),
+              child: Text(backendName + ' | ' + acceleratorName)),
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [

--- a/mobile_back_pixel/cpp/backend_tflite/tflite_pixel.cc
+++ b/mobile_back_pixel/cpp/backend_tflite/tflite_pixel.cc
@@ -269,6 +269,11 @@ const char* mlperf_backend_vendor_name(mlperf_backend_ptr_t backend_ptr) {
   return backend_data->vendor;
 }
 
+// TODO: Return the name of the accelerator.
+const char* mlperf_backend_accelerator_name(mlperf_backend_ptr_t backend_ptr) {
+  return "ACCELERATOR_NAME";
+}
+
 // Return the name of this backend.
 const char* mlperf_backend_name(mlperf_backend_ptr_t backend_ptr) {
   TFLiteBackendData* backend_data = (TFLiteBackendData*)backend_ptr;

--- a/mobile_back_qti/cpp/backend_mock_qti/qti_mock_c.cc
+++ b/mobile_back_qti/cpp/backend_mock_qti/qti_mock_c.cc
@@ -26,6 +26,11 @@ const char* mlperf_backend_vendor_name(mlperf_backend_ptr_t backend_ptr) {
   return "snpe";
 }
 
+// TODO: Return the name of the accelerator.
+const char* mlperf_backend_accelerator_name(mlperf_backend_ptr_t backend_ptr) {
+  return "ACCELERATOR_NAME";
+}
+
 // Should return true if current hardware is supported.
 bool mlperf_backend_matches_hardware(const char** not_allowed_message,
                                      const char** settings,

--- a/mobile_back_qti/cpp/backend_qti/qti_c.cc
+++ b/mobile_back_qti/cpp/backend_qti/qti_c.cc
@@ -145,6 +145,11 @@ mlperf_backend_ptr_t mlperf_backend_create(
   return backend_data;
 }
 
+// TODO: Return the name of the accelerator.
+const char *mlperf_backend_accelerator_name(mlperf_backend_ptr_t backend_ptr) {
+  return "ACCELERATOR_NAME";
+}
+
 // Return the name of this backend.
 const char *mlperf_backend_name(mlperf_backend_ptr_t backend_ptr) {
   QTIBackendHelper *backend_data = (QTIBackendHelper *)backend_ptr;

--- a/mobile_back_samsung/cpp/eden_mlperf_c_backend/jni/edenai.cc
+++ b/mobile_back_samsung/cpp/eden_mlperf_c_backend/jni/edenai.cc
@@ -1360,6 +1360,11 @@ const char* mlperf_backend_vendor_name(mlperf_backend_ptr_t backend_ptr) {
   return name;
 }
 
+// TODO: Return the name of the accelerator.
+const char* mlperf_backend_accelerator_name(mlperf_backend_ptr_t backend_ptr) {
+  return "ACCELERATOR_NAME";
+}
+
 const char* mlperf_backend_name(mlperf_backend_ptr_t backend_ptr) {
   static const char name[] = "samsung";
   return name;

--- a/mobile_back_tflite/cpp/backend_tflite/tflite_c.cc
+++ b/mobile_back_tflite/cpp/backend_tflite/tflite_c.cc
@@ -379,6 +379,11 @@ const char *mlperf_backend_vendor_name(mlperf_backend_ptr_t backend_ptr) {
   return backend_data->vendor;
 }
 
+// TODO: Return the name of the accelerator.
+const char *mlperf_backend_accelerator_name(mlperf_backend_ptr_t backend_ptr) {
+  return "ACCELERATOR_NAME";
+}
+
 // Return the name of this backend.
 const char *mlperf_backend_name(mlperf_backend_ptr_t backend_ptr) {
   TFLiteBackendData *backend_data = (TFLiteBackendData *)backend_ptr;


### PR DESCRIPTION
Closes #203.

Each vendor should modify the function `mlperf_backend_accelerator_name` and return the appropriate accelerator name.