### PR TITLE
Refactor ComputeLatency() to report duration in ms and not QPS

### DIFF
--- a/flutter/cpp/flutter/main.cc
+++ b/flutter/cpp/flutter/main.cc
@@ -141,16 +141,7 @@ extern "C" struct dart_ffi_run_benchmark_out* dart_ffi_run_benchmark(
 
   auto out = new dart_ffi_run_benchmark_out;
   out->ok = 1;
-
-  // TODO (anhappdev): Refactor the C++ code so that ComputeLatency() only
-  // report duration in ms and not QPS (but after moving `android/cpp` out of
-  // `android` folder). See
-  // https://github.com/mlcommons/mobile_app_open/issues/237
-  if (std::string{in->scenario} == "Offline") {
-    out->latency = 1000.0 / driver.ComputeLatency();
-  } else {
-    out->latency = driver.ComputeLatency();
-  }
+  out->latency = driver.ComputeLatency();
   out->accuracy = strdup(driver.ComputeAccuracyString().c_str());
   out->num_samples = driver.GetNumSamples();
   out->duration_ms = driver.GetDurationMs();

--- a/flutter/cpp/mlperf_driver.h
+++ b/flutter/cpp/mlperf_driver.h
@@ -68,7 +68,6 @@ class MlperfDriver : public ::mlperf::SystemUnderTest {
       return 0.0f;
     }
     if (scenario_ == "Offline") {
-      //      return 1000.0 / (1000.0 * GetNumSamples() / GetDurationMs());
       return GetDurationMs() / GetNumSamples();
     }
     std::sort(latencies_ns_.begin(), latencies_ns_.end());

--- a/flutter/cpp/mlperf_driver.h
+++ b/flutter/cpp/mlperf_driver.h
@@ -68,7 +68,8 @@ class MlperfDriver : public ::mlperf::SystemUnderTest {
       return 0.0f;
     }
     if (scenario_ == "Offline") {
-      return 1000.0f * GetNumSamples() / GetDurationMs();
+      //      return 1000.0 / (1000.0 * GetNumSamples() / GetDurationMs());
+      return GetDurationMs() / GetNumSamples();
     }
     std::sort(latencies_ns_.begin(), latencies_ns_.end());
     return static_cast<float>(latencies_ns_[latencies_ns_.size() * 0.9]) / 1e6;
@@ -81,11 +82,7 @@ class MlperfDriver : public ::mlperf::SystemUnderTest {
     }
     std::stringstream stream;
     stream << std::fixed << std::setprecision(2) << ComputeLatency();
-    if (scenario_ == "Offline") {
-      stream << " qps";
-    } else {
-      stream << " ms";
-    }
+    stream << " ms";
     return stream.str();
   }
 


### PR DESCRIPTION
Related to #237 