### PR TITLE
Make `single_stream_expected_latency_ns` configurable in benchmark_setting for Android app

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,8 @@ tf_workspace2()
 android_sdk_repository(
     name = "androidsdk",
     api_level = 30,
+    # 30.0.3 required, see https://stackoverflow.com/a/68036845
+    build_tools_version = "30.0.3",
 )
 
 android_ndk_repository(

--- a/android/cpp/binary/main.cc
+++ b/android/cpp/binary/main.cc
@@ -98,7 +98,8 @@ int Main(int argc, char* argv[]) {
 
   // Command Line Flags for mlperf.
   std::string mode, scenario = "SingleStream", output_dir;
-  int min_query_count = 100, min_duration = 100;
+  int min_query_count = 100, min_duration = 100,
+      single_stream_expected_latency_ns = 1000000;
   flag_list.clear();
   flag_list.insert(
       flag_list.end(),
@@ -112,6 +113,9 @@ int Main(int argc, char* argv[]) {
        Flag::CreateFlag("min_duration", &min_duration,
                         "The test will guarantee to run at least this "
                         "duration in performance mode. The duration is in ms."),
+       Flag::CreateFlag("single_stream_expected_latency_ns",
+                        &single_stream_expected_latency_ns,
+                        "The single stream expected latency in ns."),
        Flag::CreateFlag("output_dir", &output_dir,
                         "The output directory of mlperf.", Flag::kRequired)});
 
@@ -325,7 +329,8 @@ int Main(int argc, char* argv[]) {
   // Running mlperf.
   MlperfDriver driver(std::move(dataset), std::move(backend), scenario,
                       batch_size);
-  driver.RunMLPerfTest(mode, min_query_count, min_duration, output_dir);
+  driver.RunMLPerfTest(mode, min_query_count, min_duration,
+                       single_stream_expected_latency_ns, output_dir);
   LOG(INFO) << "90 percentile latency: " << driver.ComputeLatencyString();
   LOG(INFO) << "Accuracy: " << driver.ComputeAccuracyString();
   return 0;

--- a/android/cpp/mlperf_driver.cc
+++ b/android/cpp/mlperf_driver.cc
@@ -83,6 +83,7 @@ void MlperfDriver::IssueQuery(
 
 void MlperfDriver::RunMLPerfTest(const std::string& mode, int min_query_count,
                                  int min_duration,
+                                 int single_stream_expected_latency_ns,
                                  const std::string& output_dir) {
   // Setting the mlperf configs.
   ::mlperf::TestSettings mlperf_settings;
@@ -102,8 +103,9 @@ void MlperfDriver::RunMLPerfTest(const std::string& mode, int min_query_count,
   } else {
     // Run MLPerf in SingleStream mode by default.
     mlperf_settings.scenario = ::mlperf::TestScenario::SingleStream;
-    mlperf_settings.single_stream_expected_latency_ns = 900000;
     mlperf_settings.min_duration_ms = min_duration;
+    mlperf_settings.single_stream_expected_latency_ns =
+        single_stream_expected_latency_ns;
   }
 
   ::mlperf::StartTest(this, dataset_.get(), mlperf_settings, log_settings);

--- a/android/cpp/mlperf_driver.h
+++ b/android/cpp/mlperf_driver.h
@@ -44,7 +44,8 @@ class MlperfDriver : public ::mlperf::SystemUnderTest {
 
   // Runs MLPerf tests.
   void RunMLPerfTest(const std::string& mode, int min_query_count,
-                     int min_duration, const std::string& output_dir);
+                     int min_duration, int single_stream_expected_latency_ns,
+                     const std::string& output_dir);
 
   // A human-readable string for loggin purposes.
   const std::string& Name() const override { return backend_->Name(); }

--- a/android/cpp/proto/backend_setting.proto
+++ b/android/cpp/proto/backend_setting.proto
@@ -47,6 +47,8 @@ message BenchmarkSetting {
   required string configuration = 6;
   // batch_size is passed to the backend
   optional int32 batch_size = 7;
+  // single_stream_expected_latency_ns is passed to the MlperfDriver, default to 1M, max 1M
+  optional int32 single_stream_expected_latency_ns = 8 [default = 1000000];
 }
 
 // Common setting of each benchmark

--- a/android/docker/mlperf_mobile/Dockerfile
+++ b/android/docker/mlperf_mobile/Dockerfile
@@ -55,7 +55,7 @@ RUN mkdir -p ${android_home} && \
 ENV ANDROID_HOME ${android_home}
 ENV ANDROID_NDK_HOME ${android_ndk_home}
 ENV ADB_INSTALL_TIMEOUT 120
-ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/build-tools/29.0.3:${PATH}
+ENV PATH=${ANDROID_HOME}/emulator:${ANDROID_HOME}/cmdline-tools/tools/bin:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/build-tools/30.0.3:${PATH}
 
 RUN mkdir ~/.android && echo '### User Sources for Android SDK Manager' > ~/.android/repositories.cfg
 

--- a/android/docker/mlperf_mobile/Dockerfile
+++ b/android/docker/mlperf_mobile/Dockerfile
@@ -67,7 +67,7 @@ RUN yes | sdkmanager \
     "extras;android;m2repository" \
     "extras;google;m2repository" \
     "extras;google;google_play_services" \
-    "build-tools;29.0.3"
+    "build-tools;30.0.3"
 
 ARG android_version=30
 RUN sdkmanager "platforms;android-${android_version}" "cmake;3.6.4111459"

--- a/android/java/org/mlperf/inference/MLPerfDriverWrapper.java
+++ b/android/java/org/mlperf/inference/MLPerfDriverWrapper.java
@@ -35,11 +35,18 @@ public final class MLPerfDriverWrapper implements AutoCloseable {
    * @param minQueryCount is the minimum number of samples should be run.
    * @param minDurationMs is the minimum duration in ms. After both conditions are met, the test
    *     ends.
+   * @param singleStreamExpectedLatencyNs is the expected latency in ns for single stream scenario.
    * @param outputDir is the directory to store the log files.
    */
   @SuppressWarnings("JavadocReference")
-  public void runMLPerf(String mode, int minQueryCount, int minDurationMs, String outputDir) {
-    nativeRun(driverHandle, mode, minQueryCount, minDurationMs, outputDir);
+  public void runMLPerf(
+      String mode,
+      int minQueryCount,
+      int minDurationMs,
+      int singleStreamExpectedLatencyNs,
+      String outputDir) {
+    nativeRun(
+        driverHandle, mode, minQueryCount, minDurationMs, singleStreamExpectedLatencyNs, outputDir);
   }
 
   // The latency in ms is formatted with two decimal places.
@@ -83,7 +90,12 @@ public final class MLPerfDriverWrapper implements AutoCloseable {
       long datasetHandle, long backendHandle, String scenario, int batch);
 
   private native void nativeRun(
-      long driverHandle, String jmode, int minQueryCount, int minDuration, String outputDir);
+      long driverHandle,
+      String jmode,
+      int minQueryCount,
+      int minDuration,
+      int singleStreamExpectedLatencyNs,
+      String outputDir);
 
   private native float nativeGetLatency(long handle);
 

--- a/android/java/org/mlperf/inference/jni/mlperf_driver_jni.cc
+++ b/android/java/org/mlperf/inference/jni/mlperf_driver_jni.cc
@@ -81,13 +81,15 @@ Java_org_mlperf_inference_MLPerfDriverWrapper_nativeInit(
 
 JNIEXPORT void JNICALL Java_org_mlperf_inference_MLPerfDriverWrapper_nativeRun(
     JNIEnv* env, jclass clazz, jlong driver_handle, jstring jmode,
-    jint min_query_count, jint min_duration, jstring joutput_dir) {
+    jint min_query_count, jint min_duration,
+    jint single_stream_expected_latency_ns, jstring joutput_dir) {
   // Convert parameters to C++.
   std::string mode = env->GetStringUTFChars(jmode, nullptr);
   std::string output_dir = env->GetStringUTFChars(joutput_dir, nullptr);
   // Start the test.
   convertLongToMlperfDriver(env, driver_handle)
-      ->RunMLPerfTest(mode, min_query_count, min_duration, output_dir);
+      ->RunMLPerfTest(mode, min_query_count, min_duration,
+                      single_stream_expected_latency_ns, output_dir);
 }
 
 JNIEXPORT jfloat JNICALL

--- a/mobile_back_qti/cpp/backend_qti/qti_settings.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings.h
@@ -566,6 +566,7 @@ benchmark_setting {
     value: "true"
   }
   src: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  single_stream_expected_latency_ns: 800000
 }
 
 benchmark_setting {

--- a/mobile_back_samsung/cpp/sbe_backend/jni/include/sbe_config.hpp
+++ b/mobile_back_samsung/cpp/sbe_backend/jni/include/sbe_config.hpp
@@ -173,6 +173,7 @@ benchmark_setting {
     value: "false"
   }
   src: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/is.nnc"
+  single_stream_expected_latency_ns: 900000
 }
 
 benchmark_setting {
@@ -322,6 +323,7 @@ benchmark_setting {
     value: "false"
   }
   src: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_offline.nnc"
+  single_stream_expected_latency_ns: 900000
 })SETTINGS";
 
 const std::string sbe1200_config = R"SETTINGS(
@@ -411,6 +413,7 @@ benchmark_setting {
     value: "Uint8"
   }
   src: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/is.nnc"
+  single_stream_expected_latency_ns: 900000
 }
 
 benchmark_setting {
@@ -460,6 +463,7 @@ benchmark_setting {
     value: "Float32"
   }
   src: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_offline.nnc"
+  single_stream_expected_latency_ns: 900000
 })SETTINGS";
 
 }  // namespace sbe


### PR DESCRIPTION
Closes https://github.com/mlcommons/mobile_app_open/issues/291