### PR TITLE
Add support for second accuracy in UI

### DIFF
--- a/flutter/cpp/flutter/dart_run_benchmark.h
+++ b/flutter/cpp/flutter/dart_run_benchmark.h
@@ -32,6 +32,8 @@ struct dart_ffi_run_benchmark_out {
   float latency;
   float accuracy_normalized;
   char *accuracy_formatted;
+  float accuracy_normalized2;
+  char *accuracy_formatted2;
   int32_t num_samples;
   float duration_ms;
   char *backend_name;

--- a/flutter/documentation/extended-result.schema.json
+++ b/flutter/documentation/extended-result.schema.json
@@ -208,6 +208,16 @@
                         }
                     ]
                 },
+                "accuracy2": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/Accuracy"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "dataset": {
                     "$ref": "#/definitions/Dataset"
                 },
@@ -226,6 +236,7 @@
             },
             "required": [
                 "accuracy",
+                "accuracy2",
                 "dataset",
                 "loadgen_validity",
                 "measured_duration_ms",

--- a/flutter/lib/backend/bridge/ffi_run.dart
+++ b/flutter/lib/backend/bridge/ffi_run.dart
@@ -78,6 +78,9 @@ class _RunOut extends Struct {
   @Float()
   external double accuracyNormalized;
   external Pointer<Utf8> accuracyFormatted;
+  @Float()
+  external double accuracyNormalized2;
+  external Pointer<Utf8> accuracyFormatted2;
   @Int32()
   external int num_samples;
   @Float()
@@ -119,6 +122,8 @@ RunResult runBenchmark(RunSettings rs) {
     throughput: 1000.0 / runOut.ref.latency,
     accuracyNormalized: runOut.ref.accuracyNormalized,
     accuracyFormatted: runOut.ref.accuracyFormatted.toDartString(),
+    accuracyNormalized2: runOut.ref.accuracyNormalized2,
+    accuracyFormatted2: runOut.ref.accuracyFormatted2.toDartString(),
     numSamples: runOut.ref.num_samples,
     durationMs: runOut.ref.duration_ms,
     backendName: runOut.ref.backend_name.toDartString(),

--- a/flutter/lib/backend/bridge/run_result.dart
+++ b/flutter/lib/backend/bridge/run_result.dart
@@ -1,9 +1,11 @@
 class RunResult {
+  final double throughput;
   final double accuracyNormalized;
   final String accuracyFormatted;
+  final double accuracyNormalized2;
+  final String accuracyFormatted2;
   final int numSamples;
   final double durationMs;
-  final double throughput;
   final String backendName;
   final String backendVendor;
   final String acceleratorName;
@@ -13,6 +15,8 @@ class RunResult {
   RunResult({
     required this.accuracyNormalized,
     required this.accuracyFormatted,
+    required this.accuracyNormalized2,
+    required this.accuracyFormatted2,
     required this.numSamples,
     required this.durationMs,
     required this.backendName,

--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -16,6 +16,7 @@ import 'run_mode.dart';
 class BenchmarkResult {
   final double throughput;
   final Accuracy? accuracy;
+  final Accuracy? accuracy2;
   final String backendName;
   final String acceleratorName;
   final int batchSize;
@@ -25,6 +26,7 @@ class BenchmarkResult {
   BenchmarkResult(
       {required this.throughput,
       required this.accuracy,
+      required this.accuracy2,
       required this.backendName,
       required this.acceleratorName,
       required this.batchSize,
@@ -33,6 +35,7 @@ class BenchmarkResult {
 
   static const _tagThroughput = 'throughput';
   static const _tagAccuracy = 'accuracy';
+  static const _tagAccuracy2 = 'accuracy2';
   static const _tagBackendName = 'backend_name';
   static const _tagAcceleratorName = 'accelerator_name';
   static const _tagBatchSize = 'batch_size';
@@ -44,6 +47,7 @@ class BenchmarkResult {
     return BenchmarkResult(
       throughput: json[_tagThroughput] as double,
       accuracy: Accuracy.fromJson(json[_tagAccuracy] as Map<String, dynamic>),
+      accuracy2: Accuracy.fromJson(json[_tagAccuracy2] as Map<String, dynamic>),
       backendName: json[_tagBackendName] as String,
       acceleratorName: json[_tagAcceleratorName] as String,
       batchSize: json[_tagBatchSize] as int,
@@ -55,6 +59,7 @@ class BenchmarkResult {
   Map<String, dynamic> toJson() => {
         _tagThroughput: throughput,
         _tagAccuracy: accuracy,
+        _tagAccuracy2: accuracy2,
         _tagBackendName: backendName,
         _tagAcceleratorName: acceleratorName,
         _tagBatchSize: batchSize,

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -257,6 +257,12 @@ class BenchmarkState extends ChangeNotifier {
                 normalized: performanceResult.accuracyNormalized,
                 formatted: performanceResult.accuracyFormatted,
               ),
+        accuracy2: performanceResult.accuracyNormalized2 < 0.0
+            ? null
+            : Accuracy(
+                normalized: performanceResult.accuracyNormalized2,
+                formatted: performanceResult.accuracyFormatted2,
+              ),
         backendName: performanceResult.backendName,
         acceleratorName: performanceResult.acceleratorName,
         batchSize: benchmark.config.batchSize,
@@ -287,12 +293,17 @@ class BenchmarkState extends ChangeNotifier {
                   normalized: accuracyResult.accuracyNormalized,
                   formatted: accuracyResult.accuracyFormatted,
                 ),
+          accuracy2: accuracyResult.accuracyNormalized2 < 0.0
+              ? null
+              : Accuracy(
+                  normalized: accuracyResult.accuracyNormalized2,
+                  formatted: accuracyResult.accuracyFormatted2,
+                ),
           backendName: accuracyResult.backendName,
           acceleratorName: accuracyResult.acceleratorName,
           batchSize: benchmark.config.batchSize,
           threadsNumber: benchmark.config.threadsNumber,
-          validity: accuracyResult.accuracyNormalized >= 0.0 &&
-              accuracyResult.accuracyNormalized <= 1.0,
+          validity: accuracyResult.validity,
         );
       }
 
@@ -336,6 +347,12 @@ class BenchmarkState extends ChangeNotifier {
                   normalized: performance.accuracyNormalized,
                   formatted: performance.accuracyFormatted,
                 ),
+          accuracy2: performance.accuracyNormalized2 < 0.0
+              ? null
+              : Accuracy(
+                  normalized: performance.accuracyNormalized2,
+                  formatted: performance.accuracyFormatted2,
+                ),
           datasetInfo: DatasetInfo(
             name: benchmark.taskConfig.liteDataset.name,
             type: DatasetType.fromJson(
@@ -358,6 +375,12 @@ class BenchmarkState extends ChangeNotifier {
                     : Accuracy(
                         normalized: accuracy.accuracyNormalized,
                         formatted: accuracy.accuracyFormatted,
+                      ),
+                accuracy2: accuracy.accuracyNormalized2 < 0.0
+                    ? null
+                    : Accuracy(
+                        normalized: accuracy.accuracyNormalized2,
+                        formatted: accuracy.accuracyFormatted2,
                       ),
                 datasetInfo: DatasetInfo(
                   name: benchmark.taskConfig.liteDataset.name,

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -109,6 +109,7 @@ class ResultManager {
     return BenchmarkResult(
         throughput: runResult.throughput ?? 0.0,
         accuracy: runResult.accuracy,
+        accuracy2: runResult.accuracy2,
         backendName: export.backendInfo.name,
         acceleratorName: export.backendInfo.accelerator,
         batchSize: export.backendSettingsInfo.batchSize,

--- a/flutter_common/lib/data/generation_helpers/edit_json_schema.main.dart
+++ b/flutter_common/lib/data/generation_helpers/edit_json_schema.main.dart
@@ -42,6 +42,7 @@ Future<void> main() async {
   makeNullable(definitions['Result']['properties']['accuracy_run']);
   makeNullable(definitions['Run']['properties']['throughput']);
   makeNullable(definitions['Run']['properties']['accuracy']);
+  makeNullable(definitions['Run']['properties']['accuracy2']);
   (definitions['Run']['properties']['start_datetime'] as Map<String, dynamic>)
       .remove('format');
 

--- a/flutter_common/lib/data/generation_helpers/write_json_example.main.dart
+++ b/flutter_common/lib/data/generation_helpers/write_json_example.main.dart
@@ -32,6 +32,10 @@ Future<void> main() async {
       normalized: 0.123,
       formatted: '12.3%',
     ),
+    accuracy2: Accuracy(
+      normalized: 0.123,
+      formatted: '12.3%',
+    ),
     datasetInfo: DatasetInfo(
       name: 'Imagenet classification validation set',
       type: DatasetType.fromJson('IMAGENET'),

--- a/flutter_common/lib/data/results/benchmark_result.dart
+++ b/flutter_common/lib/data/results/benchmark_result.dart
@@ -30,6 +30,7 @@ class Accuracy {
 class BenchmarkRunResult {
   static const String _tagThroughput = 'throughput';
   static const String _tagAccuracy = 'accuracy';
+  static const String _tagAccuracy2 = 'accuracy2';
   static const String _tagDatasetInfo = 'dataset';
   static const String _tagMeasuredDuration = 'measured_duration_ms';
   static const String _tagMeasuredSamples = 'measured_samples';
@@ -38,6 +39,7 @@ class BenchmarkRunResult {
 
   final double? throughput;
   final Accuracy? accuracy;
+  final Accuracy? accuracy2;
   final DatasetInfo datasetInfo;
   final double measuredDurationMs;
   final int measuredSamples;
@@ -47,6 +49,7 @@ class BenchmarkRunResult {
   BenchmarkRunResult({
     required this.throughput,
     required this.accuracy,
+    required this.accuracy2,
     required this.datasetInfo,
     required this.measuredDurationMs,
     required this.measuredSamples,
@@ -60,6 +63,9 @@ class BenchmarkRunResult {
           accuracy: json[_tagAccuracy] == null
               ? null
               : Accuracy.fromJson(json[_tagAccuracy]),
+          accuracy2: json[_tagAccuracy2] == null
+              ? null
+              : Accuracy.fromJson(json[_tagAccuracy2]),
           datasetInfo: DatasetInfo.fromJson(json[_tagDatasetInfo]),
           measuredDurationMs: json[_tagMeasuredDuration] as double,
           measuredSamples: json[_tagMeasuredSamples] as int,
@@ -70,6 +76,7 @@ class BenchmarkRunResult {
   Map<String, dynamic> toJson() => {
         _tagThroughput: throughput,
         _tagAccuracy: accuracy,
+        _tagAccuracy2: accuracy2,
         _tagDatasetInfo: datasetInfo,
         _tagMeasuredDuration: measuredDurationMs,
         _tagMeasuredSamples: measuredSamples,


### PR DESCRIPTION
Closes https://github.com/mlcommons/mobile_app_open/issues/294

Currently no dataset supports 2 accuracy values so second accuracy is disabled.
When we have a dataset that provides a second accuracy value enabling it in UI will be very simple.