### PR TITLE
Make neuron backend work

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,12 +55,13 @@ android_workspace()
 #    name = "androidndk",
 #)
 
-http_archive(
-    name = "neuron_delegate",
-    sha256 = "2e4600c99c9b4ea7a129108cd688419eeef9b2aeabf05df6f385258e19ca96c4",
-    strip_prefix = "tflite-neuron-delegate-2.6.0",
-    urls = ["https://github.com/MediaTek-NeuroPilot/tflite-neuron-delegate/archive/v2.6.0.tar.gz"],
-)
+# use Neuron Delegate aar before we have updated source code
+#http_archive(
+#    name = "neuron_delegate",
+#    sha256 = "2e4600c99c9b4ea7a129108cd688419eeef9b2aeabf05df6f385258e19ca96c4",
+#    strip_prefix = "tflite-neuron-delegate-2.6.0",
+#    urls = ["https://github.com/MediaTek-NeuroPilot/tflite-neuron-delegate/archive/v2.6.0.tar.gz"],
+#)
 
 new_local_repository(
     name = "samsungbackend",

--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,14 @@
         android:icon="@mipmap/ic_launcher">
         <uses-native-library
               android:name="libcdsprpc.so"
+              android:required="false"
+              />
+        <uses-native-library
+              android:name="libneuronusdk_adapter.mtk.so"
+              android:required="false"
+              />
+        <uses-native-library
+              android:name="libapuwareutils_v2.mtk.so"
               android:required="false" 
               />
         <activity

--- a/flutter/flutter.mk
+++ b/flutter/flutter.mk
@@ -117,11 +117,7 @@ flutter/build-info:
 flutter/protobuf:
 	rm -rf flutter/lib/protos
 	mkdir -p flutter/lib/protos
-	# since we are gonna build protobuf, build the protoc
-	bazel build -c opt --spawn_strategy=standalone \
-		@com_google_protobuf//:protoc
-	bazel-bin/external/com_google_protobuf/protoc \
-		--proto_path flutter/cpp/proto \
+	protoc --proto_path flutter/cpp/proto \
 		--dart_out flutter/lib/protos \
 		flutter/cpp/proto/*.proto
 	dart format flutter/lib/protos

--- a/flutter/flutter.mk
+++ b/flutter/flutter.mk
@@ -117,7 +117,11 @@ flutter/build-info:
 flutter/protobuf:
 	rm -rf flutter/lib/protos
 	mkdir -p flutter/lib/protos
-	protoc --proto_path flutter/cpp/proto \
+	# since we are gonna build protobuf, build the protoc
+	bazel build -c opt --spawn_strategy=standalone \
+		@com_google_protobuf//:protoc
+	bazel-bin/external/com_google_protobuf/protoc \
+		--proto_path flutter/cpp/proto \
 		--dart_out flutter/lib/protos \
 		flutter/cpp/proto/*.proto
 	dart format flutter/lib/protos

--- a/mobile_back_tflite/cpp/backend_tflite/neuron/README.md
+++ b/mobile_back_tflite/cpp/backend_tflite/neuron/README.md
@@ -1,0 +1,4 @@
+get `libtensorflowlite_neuron_jni.so` from `tensorflow-lite-neuron.aar`
+and let it be `jni/arm64-v8a/libtensorflowlite_neuron_jni.so`. e.g.,
+
+* unzip tensorflow-lite-neuron.aar jni/arm64-v8a/libtensorflowlite_neuron_jni.so

--- a/mobile_back_tflite/cpp/backend_tflite/neuron/README.md
+++ b/mobile_back_tflite/cpp/backend_tflite/neuron/README.md
@@ -1,3 +1,5 @@
+# getting neuron delegate so binary
+
 get `libtensorflowlite_neuron_jni.so` from `tensorflow-lite-neuron.aar`
 and let it be `jni/arm64-v8a/libtensorflowlite_neuron_jni.so`. e.g.,
 

--- a/mobile_back_tflite/cpp/backend_tflite/neuron/tflite_settings_mtk.h
+++ b/mobile_back_tflite/cpp/backend_tflite/neuron/tflite_settings_mtk.h
@@ -60,11 +60,11 @@ benchmark_setting {
 benchmark_setting {
   benchmark_id: "LU_float32"
   accelerator: "neuron"
-  accelerator_desc: "neuron"
+  accelerator_desc: "Neuron"
   configuration: "TFLite"
   batch_size: 1
-  src: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-  md5Checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+  src: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_20200602.tflite"
+  md5Checksum: "3a636c066ca2916e1858266857e96c72"
 }
 
 benchmark_setting {
@@ -79,8 +79,8 @@ benchmark_setting {
 
 benchmark_setting {
   benchmark_id: "IS_uint8_mosaic"
-  accelerator: "nnapi"
-  accelerator_desc: "NNAPI"
+  accelerator: "neuron"
+  accelerator_desc: "Neuron"
   configuration: "TFLite"
   src: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
   md5Checksum: "b7a7620b8b818d64305b51ab796bfb1d"

--- a/mobile_back_tflite/cpp/backend_tflite/tflite_c.cc
+++ b/mobile_back_tflite/cpp/backend_tflite/tflite_c.cc
@@ -206,7 +206,11 @@ mlperf_backend_ptr_t mlperf_backend_create(
     //   if it is not specified in settings.
     // If we don't use batching, we will use shards_num=1,
     //   which is the default value.
+#if defined(__ANDROID__) && defined(MTK_TFLITE_NEURON_BACKEND)
+    backend_data->shards_num = 4;
+#else
     backend_data->shards_num = 2;
+#endif
 
     // TODO convert this to a member var
     for (int i = 0; i < configs->count; ++i) {

--- a/mobile_back_tflite/tflite_backend.mk
+++ b/mobile_back_tflite/tflite_backend.mk
@@ -28,7 +28,7 @@ ifeq (${WITH_MEDIATEK},1)
   $(info WITH_MEDIATEK=1)
   backend_mediatek_android_files= \
     ${BAZEL_LINKS_PREFIX}bin/mobile_back_tflite/cpp/backend_tflite/libtfliteneuronbackend.so \
-    ${BAZEL_LINKS_PREFIX}bin/external/neuron_delegate/neuron/java/libtensorflowlite_neuron_jni.so
+	mobile_back_tflite/cpp/backend_tflite/neuron/jni/arm64-v8a/libtensorflowlite_neuron_jni.so
   backend_mediatek_android_target=//mobile_back_tflite/cpp/backend_tflite:libtfliteneuronbackend.so
   backend_mediatek_filename=libtfliteneuronbackend
 endif


### PR DESCRIPTION
1. use Neuron Delegate in `tensorflow-lite-neuron.aar` for now (will use source code neuron delegate repo when it's ready later)
2. for Android API level 31 and later, we need `uses-native-library` when using underlying vendor libs
3. fix some neuron delegate settings
4. ~~since we build and use protobuf, we can build `protoc` from protobuf instead of depending on system package~~