### PR TITLE
Fix build error due to missing android build tools

### DIFF
--- a/flutter/android/docker/Dockerfile
+++ b/flutter/android/docker/Dockerfile
@@ -32,7 +32,8 @@ ENV PATH=$PATH:$ANDROID_SDK_ROOT/cmdline-tools/tools/bin
 RUN yes | sdkmanager --licenses >/dev/null
 RUN yes | sdkmanager \
     "platform-tools" \
-    "build-tools;29.0.2" \
+    "build-tools;30.0.3" \
+    "platforms;android-29" \
     "platforms;android-31"
 # Install NDK in a separate layer to decrease max layer size.
 RUN yes | sdkmanager "ndk;21.4.7075529"


### PR DESCRIPTION
I have tried to build fluter apk with a clean ubuntu VM and it failed as well.

How to reproduce
```
make WITH_PIXEL=1 docker/flutter/android/apk
```
Error message
```
💪 Building with sound null safety 💪

Checking the license for package Android SDK Build-Tools 30.0.3 in /opt/android/licenses
License for package Android SDK Build-Tools 30.0.3 accepted.
Preparing "Install Android SDK Build-Tools 30.0.3 (revision: 30.0.3)".
Warning: Failed to read or create install properties file.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:packageRelease'.
> Could not create task ':app:minifyReleaseWithR8'.
   > Failed to install the following SDK components:
         build-tools;30.0.3 Android SDK Build-Tools 30.0.3
     The SDK directory is not writable (/opt/android)


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1m 51s
Running Gradle task 'assembleRelease'...                          111.6s
Gradle task assembleRelease failed with exit code 1
make: *** [flutter/android/android.mk:59: flutter/android/apk-only] Error 1
make: *** [flutter/android/android.mk:65: docker/flutter/android/apk] Error 2
```