### PR TITLE
Change pixel backend name as "TFLite-pixel"

### DIFF
--- a/mobile_back_pixel/cpp/backend_tflite/tflite_pixel.cc
+++ b/mobile_back_pixel/cpp/backend_tflite/tflite_pixel.cc
@@ -37,7 +37,7 @@ limitations under the License.
 #define N_OFFLINE_INTERPRETERS 8
 
 struct TFLiteBackendData {
-  const char* name = "TFLite";
+  const char* name = "TFLite-pixel";
   const char* vendor = "Google";
   TfLiteModel* model{nullptr};
   std::vector<TfLiteInterpreterOptions*> options{};


### PR DESCRIPTION
So it could be distinguished with the default TFLite backend.