### PR TITLE
Properly handle exceptions in handleResources and runBenchmarks

### DIFF
--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -148,7 +148,7 @@ class BenchmarkState extends ChangeNotifier {
     notifyListeners();
     try {
       await setTaskConfig(name: _store.chosenConfigurationName);
-      await loadResources();
+      deferredLoadResources();
     } catch (e, trace) {
       print("can't load resources: $e");
       print(trace);

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -174,7 +174,8 @@ class BenchmarkState extends ChangeNotifier {
     }
 
     await Wakelock.enable();
-    resourceManager.handleResources(_middle.listResources(), needToPurgeCache);
+    await resourceManager.handleResources(
+        _middle.listResources(), needToPurgeCache);
 
     taskConfigFailedToLoad = false;
     await Wakelock.disable();

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -242,7 +242,7 @@ class BenchmarkState extends ChangeNotifier {
       await _runBenchmarks();
       print('Benchmarks finished');
       _doneRunning = _aborting ? null : true;
-    } catch(e) {
+    } catch (e) {
       _doneRunning = null;
       rethrow;
     } finally {

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -84,6 +84,7 @@
   "uploadButton": "Upload results",
   "uploadSuccess": "Results uploaded successfully",
   "uploadFail": "Error uploading results",
+  "runFail": "Error while running benchmarks",
 
   "notAvailable": "N/A",
 

--- a/flutter/lib/main.dart
+++ b/flutter/lib/main.dart
@@ -71,7 +71,7 @@ void autostartHandler(BenchmarkState state, Store store) async {
         const bool.fromEnvironment('submission', defaultValue: false);
     store.offlineMode =
         const bool.fromEnvironment('offline', defaultValue: false);
-    state.runBenchmarks();
+    await state.runBenchmarks();
     return;
   }
   if (state.state == BenchmarkStateEnum.done) {

--- a/flutter/lib/resources/archive_cache_helper.dart
+++ b/flutter/lib/resources/archive_cache_helper.dart
@@ -33,6 +33,7 @@ class ArchiveCacheHelper {
   }
 
   Future<Directory> _unzipFile(String archivePath) async {
+    print('unpacking $archivePath');
     final result = Directory(_getArchiveFolder(archivePath));
     await result.create(recursive: true);
 

--- a/flutter/lib/resources/file_cache_helper.dart
+++ b/flutter/lib/resources/file_cache_helper.dart
@@ -44,13 +44,14 @@ class FileCacheHelper {
   }
 
   Future<File> _download(String url) async {
-    const succesStatusCode = 200;
+    print('downloading $url');
+    const successStatusCode = 200;
 
     final response = await _httpClient
         .getUrl(Uri.parse(url))
         .then((request) => request.close());
 
-    if (response.statusCode != succesStatusCode) {
+    if (response.statusCode != successStatusCode) {
       throw 'Could not download file by url: status ${response.statusCode}, url: $url';
     }
 

--- a/flutter/lib/resources/resource_manager.dart
+++ b/flutter/lib/resources/resource_manager.dart
@@ -61,7 +61,8 @@ class ResourceManager {
     return checksum == md5Checksum;
   }
 
-  Future<void> handleResources(List<Resource> resources, bool purgeOldCache) async {
+  Future<void> handleResources(
+      List<Resource> resources, bool purgeOldCache) async {
     _progressString = '0%';
     _done = false;
     _onUpdate();

--- a/flutter/lib/resources/resource_manager.dart
+++ b/flutter/lib/resources/resource_manager.dart
@@ -61,7 +61,7 @@ class ResourceManager {
     return checksum == md5Checksum;
   }
 
-  void handleResources(List<Resource> resources, bool purgeOldCache) async {
+  Future<void> handleResources(List<Resource> resources, bool purgeOldCache) async {
     _progressString = '0%';
     _done = false;
     _onUpdate();

--- a/flutter/lib/ui/root/main_screen.dart
+++ b/flutter/lib/ui/root/main_screen.dart
@@ -125,7 +125,13 @@ class MyHomePage extends StatelessWidget {
             }
           }
         }
-        state.runBenchmarks();
+        try {
+          await state.runBenchmarks();
+        } catch (e) {
+          await showErrorDialog(
+              context, [stringResources.runFail + ':', e.toString()]);
+          return;
+        }
       }),
     );
   }

--- a/flutter/lib/ui/root/resource_error_screen.dart
+++ b/flutter/lib/ui/root/resource_error_screen.dart
@@ -70,7 +70,7 @@ class ResourceErrorScreen extends StatelessWidget {
                         onPressed: () async {
                           try {
                             await state.setTaskConfig(name: '');
-                            await state.loadResources();
+                            state.deferredLoadResources();
                           } catch (e, trace) {
                             print("can't change task config: $e");
                             print(trace);
@@ -84,7 +84,7 @@ class ResourceErrorScreen extends StatelessWidget {
                           try {
                             await state.setTaskConfig(
                                 name: store.chosenConfigurationName);
-                            await state.loadResources();
+                            state.deferredLoadResources();
                           } catch (e, trace) {
                             print("can't change task config: $e");
                             print(trace);

--- a/flutter/lib/ui/run/progress_screen.dart
+++ b/flutter/lib/ui/run/progress_screen.dart
@@ -10,7 +10,8 @@ import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/ui/run/progress_circles.dart';
 
 class ProgressScreen extends StatefulWidget {
-  static final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+  static final GlobalKey<ScaffoldState> scaffoldKey =
+      GlobalKey<ScaffoldState>();
 
   @override
   _ProgressScreenState createState() => _ProgressScreenState();

--- a/flutter/lib/ui/run/progress_screen.dart
+++ b/flutter/lib/ui/run/progress_screen.dart
@@ -10,6 +10,8 @@ import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/ui/run/progress_circles.dart';
 
 class ProgressScreen extends StatefulWidget {
+  static final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+
   @override
   _ProgressScreenState createState() => _ProgressScreenState();
 }
@@ -157,6 +159,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
     );
 
     return Scaffold(
+      key: ProgressScreen.scaffoldKey,
       body: Container(
         decoration: backgroundGradient,
         child: Column(

--- a/flutter/lib/ui/run/result_screen.dart
+++ b/flutter/lib/ui/run/result_screen.dart
@@ -19,6 +19,7 @@ import 'package:mlperfbench/ui/run/app_bar.dart';
 import 'package:mlperfbench/ui/run/list_of_benchmark_items.dart';
 import 'package:mlperfbench/ui/run/result_circle.dart';
 import '../root/main_screen.dart';
+import 'progress_screen.dart';
 
 enum _ScreenMode { performance, accuracy }
 
@@ -360,7 +361,15 @@ class _ResultScreenState extends State<ResultScreen>
                   }
                 }
               }
-              state.runBenchmarks();
+              try {
+                await state.runBenchmarks();
+              } catch (e) {
+                // current context may no longer be valid if runBenchmarks requested progress screen
+                await showErrorDialog(
+                    ProgressScreen.scaffoldKey.currentContext ?? context,
+                    [stringResources.runFail + ':', e.toString()]);
+                return;
+              }
             },
             child: Padding(
               padding: EdgeInsets.fromLTRB(0, 10, 0, 10),


### PR DESCRIPTION
Closes https://github.com/mlcommons/mobile_app_open/issues/307

If some error happens when running benchmarks application shows popup with error.
If some error happens during resource download (for example, checksum validation fails) application shows `ResourceErrorScreen` with "Clear cache" button.

<img src="https://user-images.githubusercontent.com/36223296/176548439-7d9e3af0-1f28-436c-8948-96f5a53d5a71.png" width=250><img src="https://user-images.githubusercontent.com/36223296/176548448-e9f13d1f-1b54-452e-b56b-d5b8f40d1647.png" width=250>


