### PR TITLE
Make `pub get` conditional in makefiles

### DIFF
--- a/flutter/android/android.mk
+++ b/flutter/android/android.mk
@@ -46,6 +46,7 @@ flutter_common_docker_flags= \
 		--env WITH_MEDIATEK=${WITH_MEDIATEK} \
 		--env BAZEL_ARGS_GLOBAL="${proxy_bazel_args} --output_user_root=/mnt/cache/bazel" \
 		--env OFFICIAL_BUILD=${OFFICIAL_BUILD} \
+		--env FLUTTER_FORCE_PUB_GET=1 \
 		${proxy_docker_args} \
 		${backend_qti_flutter_docker_args} \
 		${backend_samsung_docker_args} \

--- a/flutter/flutter.mk
+++ b/flutter/flutter.mk
@@ -146,9 +146,16 @@ flutter/set-windows-build-number:
 
 .PHONY: flutter/pub
 flutter/pub:
-	cd flutter && ${_start_args} flutter --no-version-check pub get
-	cd flutter_common && ${_start_args} flutter --no-version-check pub get
-	cd website && ${_start_args} flutter --no-version-check pub get
+	[ -z "${FLUTTER_FORCE_PUB_GET}" ] || rm -rf output/flutter/pub
+	make \
+		output/flutter/pub/flutter.stamp \
+		output/flutter/pub/flutter_common.stamp \
+		output/flutter/pub/website.stamp
+	[ -z "${FLUTTER_FORCE_PUB_GET}" ] || rm -rf output/flutter/pub
+output/flutter/pub/%.stamp: %/pubspec.yaml
+	cd $(shell basename $@ .stamp) && ${_start_args} flutter --no-version-check pub get
+	mkdir -p $(shell dirname $@)
+	touch $@
 
 ifneq (${FLUTTER_TEST_DEVICE},)
 flutter_test_device_arg=--device-id "${FLUTTER_TEST_DEVICE}"
@@ -166,3 +173,4 @@ flutter/run:
 .PHONY: flutter/clean
 flutter/clean:
 	cd flutter && ${_start_args} flutter --no-version-check clean
+	rm -rf output/flutter/pub

--- a/flutter/windows/windows-docker.mk
+++ b/flutter/windows/windows-docker.mk
@@ -28,6 +28,7 @@ flutter/windows/docker/--: flutter/windows/docker/image
 		--workdir "C:/workdir" \
 		--env "BAZEL_CACHE_ARG=${BAZEL_CACHE_ARG}" \
 		--env GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS} \
+		--env FLUTTER_FORCE_PUB_GET=1 \
 		${fwc_image_name} \
 		cmd
 

--- a/tools/formatter/format.mk
+++ b/tools/formatter/format.mk
@@ -19,11 +19,17 @@ format/clang:
 format/java:
 	git ls-files -z | grep --null-data "\.java$$" | xargs --null --no-run-if-empty java -jar /opt/formatters/google-java-format-1.9-all-deps.jar --replace
 
+.PHONY: format/dart/pub
+format/dart/pub:
+	cd flutter && ${_start_args} dart pub get
+	cd flutter_common && ${_start_args} dart pub get
+	cd website && ${_start_args} dart pub get
+
 .PHONY: format/dart
 format/dart:
-	cd flutter && ${_start_args} dart pub get && ${_start_args} dart run import_sorter:main
-	cd flutter_common && ${_start_args} dart pub get && ${_start_args} dart run import_sorter:main
-	cd website && ${_start_args} dart pub get && ${_start_args} dart run import_sorter:main
+	cd flutter && ${_start_args} dart run import_sorter:main
+	cd flutter_common && ${_start_args} dart run import_sorter:main
+	cd website && ${_start_args} dart run import_sorter:main
 	dart format flutter flutter_common website
 
 .PHONY: format/ts
@@ -116,9 +122,11 @@ FORMAT_DOCKER_ARGS= \
 
 .PHONY: docker/format
 docker/format: output/docker_mlperf_formatter.stamp
+	mkdir -p ~/.pub-cache
+	mkdir -p ~/.config/flutter
 	MSYS2_ARG_CONV_EXCL="*" docker run -it --rm \
 		${FORMAT_DOCKER_ARGS} \
-		make format
+		make format/dart/pub format
 
 .PHONY: docker/format/--
 docker/format/--: output/docker_mlperf_formatter.stamp


### PR DESCRIPTION
`flutter pub get` and `dart pub get` commands may be relatively slow.
On my PC `make format` is ~2 times faster without `pub get`, `make format/dart` ~3 times faster, `make flutter` ~3 times faster.

With this PR `dart pub get` is only run in docker (locally I don't get any errors when running `make format/dart` with empty cache) and `flutter pub get` is only run when there are changes in pubspec file.