### PR TITLE
Fix the issue where `make docker/format` fails at `format/ts`

### DIFF
--- a/tools/formatter/Dockerfile
+++ b/tools/formatter/Dockerfile
@@ -49,11 +49,16 @@ RUN cp $(which clang-format-10) ${FORMATTER_HOME}/clang-format
 RUN apt-get update && apt-get install -y \
     dos2unix
 
+# Install Node.js and NPM
+ENV NODE_ENV="production"
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN apt-get update && apt-get install -y nodejs && node -v
+RUN npm install --location=global npm@8.13.2 && npm --version
+RUN apt-get update && apt-get install -y build-essential
+
 # Add Markdown formatter
-RUN apt-get update && apt-get install -y \
-    nodejs npm
-RUN npm install -g --production "markdownlint-cli@0.26.0"
-RUN npm install -g --production markdown-link-check@3.9.0
+RUN npm install -g markdownlint-cli@0.26.0
+RUN npm install -g markdown-link-check@3.9.0
 
 # Add YAML linter
 RUN apt-get update && apt-get install -y \

--- a/tools/formatter/format.mk
+++ b/tools/formatter/format.mk
@@ -28,6 +28,7 @@ format/dart:
 
 .PHONY: format/ts
 format/ts:
+	cd firebase_functions/functions && ${_start_args} npm install --production=false
 	cd firebase_functions/functions && ${_start_args} npm run format
 	cd firebase_functions/functions && ${_start_args} npm run lint-fix
 


### PR DESCRIPTION
This PR address the issue where running `make docker/format` fails at `format/ts` because the tools needed are not installed.
