### PR TITLE
Use docker volume for storing pub-cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,5 +61,3 @@ See [format.mk](tools/formatter/format.mk) for more commands.
 
 Running `make format` requires you to have all the tools installed locally on your computer.
 For your convenience you can use a Docker image to format code files by running `make docker/format`.
-Note: if you have an error related to flutter when running `make docker/format`,
-try to run `cd flutter && flutter clean` to clear flutter cache, then try `make docker/format` again.

--- a/tools/formatter/format.mk
+++ b/tools/formatter/format.mk
@@ -107,8 +107,7 @@ output/docker_mlperf_formatter.stamp: tools/formatter/Dockerfile
 	touch $@
 
 FORMAT_DOCKER_ARGS= \
-	-v ~/.pub-cache:/home/mlperf/.pub-cache \
-	-v ~/.config/flutter:/home/mlperf/.config/flutter \
+	--mount source=mlperf-pubcache,target=/home/mlperf/.pub-cache \
 	-v $(CURDIR):/home/mlperf/mobile_app_open \
 	-w /home/mlperf/mobile_app_open \
 	-u `id -u`:`id -g` \

--- a/tools/formatter/format.mk
+++ b/tools/formatter/format.mk
@@ -102,8 +102,6 @@ output/docker_mlperf_formatter.stamp: tools/formatter/Dockerfile
 	docker build --progress=plain \
 		--build-arg UID=`id -u` --build-arg GID=`id -g` \
 		-t mlperf/formatter tools/formatter
-	# need to clean flutter cache first else we will have error when running `dart run import_sorter:main` later in docker
-	cd flutter && ${_start_args} flutter clean
 	touch $@
 
 FORMAT_DOCKER_ARGS= \


### PR DESCRIPTION
Sharing the `pub-cache` with docker container (Ubuntu) on a macOS machine seems to be problematic. Sometimes I need to run `flutter clean` to make it work when switching between flutter on macOS and flutter in Docker container.
Using a docker volume for storing pub-cache should resolve this issue.