### PR TITLE
use latest v2.1 loadgen

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,10 +90,10 @@ http_archive(
     name = "org_mlperf_inference",
     build_file = "@//flutter/android/third_party:loadgen.BUILD",
     patch_cmds = ["python3 loadgen/version_generator.py loadgen/version_generated.cc loadgen"],
-    sha256 = "f4c57a3f3cd71f2dac166a79ad760b824aafda7b91400889acff4a9c7dbdaf8e",
-    strip_prefix = "inference-a77ac37d07145d9f3123465a8fd18f9ebbde5d6a",
+    sha256 = "6773b97450d3cfe153affd8e0c69ad2c85393b1867712e812ea0d32336fa7041",
+    strip_prefix = "inference-5dd9ed739cc8dfeae2c5d30ec06f4cb524a4dd74",
     urls = [
-        "https://github.com/mlcommons/inference/archive/a77ac37d07145d9f3123465a8fd18f9ebbde5d6a.tar.gz",
+        "https://github.com/mlcommons/inference/archive/5dd9ed739cc8dfeae2c5d30ec06f4cb524a4dd74.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,11 @@ new_local_repository(
 http_archive(
     name = "org_mlperf_inference",
     build_file = "@//flutter/android/third_party:loadgen.BUILD",
+    patch_args = ["-p1"],
     patch_cmds = ["python3 loadgen/version_generator.py loadgen/version_generated.cc loadgen"],
+    patches = [
+        "//patches:revert_RAeportLatencyResults.patch",
+    ],
     sha256 = "6773b97450d3cfe153affd8e0c69ad2c85393b1867712e812ea0d32336fa7041",
     strip_prefix = "inference-5dd9ed739cc8dfeae2c5d30ec06f4cb524a4dd74",
     urls = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -92,7 +92,7 @@ http_archive(
     patch_args = ["-p1"],
     patch_cmds = ["python3 loadgen/version_generator.py loadgen/version_generated.cc loadgen"],
     patches = [
-        "//patches:revert_RAeportLatencyResults.patch",
+        "//patches:revert_ReportLatencyResults.patch",
     ],
     sha256 = "6773b97450d3cfe153affd8e0c69ad2c85393b1867712e812ea0d32336fa7041",
     strip_prefix = "inference-5dd9ed739cc8dfeae2c5d30ec06f4cb524a4dd74",

--- a/flutter/android/third_party/loadgen.BUILD
+++ b/flutter/android/third_party/loadgen.BUILD
@@ -9,6 +9,7 @@ exports_files(["LICENSE"])
 cc_library(
     name = "loadgen",
     srcs = [
+        "loadgen/early_stopping.cc",
         "loadgen/issue_query_controller.cc",
         "loadgen/loadgen.cc",
         "loadgen/logging.cc",
@@ -22,6 +23,7 @@ cc_library(
         "loadgen/version_generated.cc",
     ],
     hdrs = [
+        "loadgen/early_stopping.h",
         "loadgen/issue_query_controller.h",
         "loadgen/loadgen.h",
         "loadgen/query_sample.h",

--- a/flutter/cpp/mlperf_driver.h
+++ b/flutter/cpp/mlperf_driver.h
@@ -56,6 +56,13 @@ class MlperfDriver : public ::mlperf::SystemUnderTest {
   // Flush the staged queries immediately.
   void FlushQueries() override { backend_->FlushQueries(); }
 
+  // Called by loadgen to show us the recorded latencies.
+  void ReportLatencyResults(
+      const std::vector<::mlperf::QuerySampleLatency>& latencies_ns) final {
+    latencies_ns_.insert(latencies_ns_.end(), latencies_ns.begin(),
+                         latencies_ns.end());
+  }
+
   // Calculates the 90 percentile latency from reported latencies.
   float ComputeLatency() {
     if (latencies_ns_.empty()) {

--- a/flutter/cpp/mlperf_driver.h
+++ b/flutter/cpp/mlperf_driver.h
@@ -56,13 +56,6 @@ class MlperfDriver : public ::mlperf::SystemUnderTest {
   // Flush the staged queries immediately.
   void FlushQueries() override { backend_->FlushQueries(); }
 
-  // Called by loadgen to show us the recorded latencies.
-  void ReportLatencyResults(
-      const std::vector<::mlperf::QuerySampleLatency>& latencies_ns) final {
-    latencies_ns_.insert(latencies_ns_.end(), latencies_ns.begin(),
-                         latencies_ns.end());
-  }
-
   // Calculates the 90 percentile latency from reported latencies.
   float ComputeLatency() {
     if (latencies_ns_.empty()) {

--- a/patches/revert_ReportLatencyResults.patch
+++ b/patches/revert_ReportLatencyResults.patch
@@ -1,0 +1,291 @@
+diff --git a/loadgen/benchmark/repro.cpp b/loadgen/benchmark/repro.cpp
+index e724338..8b4bc8a 100644
+--- a/loadgen/benchmark/repro.cpp
++++ b/loadgen/benchmark/repro.cpp
+@@ -64,6 +64,8 @@ class BasicSUT : public mlperf::SystemUnderTest {
+     mlperf::QuerySamplesComplete(mResponses.data(), n);
+   }
+   void FlushQueries() override {}
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override{};
+ 
+  private:
+   void initResponse(int size) {
+@@ -106,6 +108,8 @@ class QueueSUT : public mlperf::SystemUnderTest {
+     mCondVar.notify_one();
+   }
+   void FlushQueries() override {}
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override{};
+ 
+  private:
+   void CompleteThread(int threadIdx) {
+@@ -181,6 +185,8 @@ class MultiBasicSUT : public mlperf::SystemUnderTest {
+     mlperf::QuerySamplesComplete(reponses.data(), n);
+   }
+   void FlushQueries() override {}
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override{};
+ 
+  private:
+   void initResponse(int size) {
+diff --git a/loadgen/bindings/c_api.cc b/loadgen/bindings/c_api.cc
+index f7c7f3c..cb653c3 100644
+--- a/loadgen/bindings/c_api.cc
++++ b/loadgen/bindings/c_api.cc
+@@ -27,13 +27,15 @@ namespace {
+ // Forwards SystemUnderTest calls to relevant callbacks.
+ class SystemUnderTestTrampoline : public SystemUnderTest {
+  public:
+-  SystemUnderTestTrampoline(ClientData client_data, std::string name,
+-                            IssueQueryCallback issue_cb,
+-                            FlushQueriesCallback flush_queries_cb)
++  SystemUnderTestTrampoline(
++      ClientData client_data, std::string name, IssueQueryCallback issue_cb,
++      FlushQueriesCallback flush_queries_cb,
++      ReportLatencyResultsCallback report_latency_results_cb)
+       : client_data_(client_data),
+         name_(std::move(name)),
+         issue_cb_(issue_cb),
+-        flush_queries_cb_(flush_queries_cb) {}
++        flush_queries_cb_(flush_queries_cb),
++        report_latency_results_cb_(report_latency_results_cb) {}
+   ~SystemUnderTestTrampoline() override = default;
+ 
+   const std::string& Name() const override { return name_; }
+@@ -44,20 +46,29 @@ class SystemUnderTestTrampoline : public SystemUnderTest {
+ 
+   void FlushQueries() override { (*flush_queries_cb_)(); }
+ 
++  void ReportLatencyResults(
++      const std::vector<QuerySampleLatency>& latencies_ns) override {
++    (*report_latency_results_cb_)(client_data_, latencies_ns.data(),
++                                  latencies_ns.size());
++  }
++
+  private:
+   ClientData client_data_;
+   std::string name_;
+   IssueQueryCallback issue_cb_;
+   FlushQueriesCallback flush_queries_cb_;
++  ReportLatencyResultsCallback report_latency_results_cb_;
+ };
+ 
+ }  // namespace
+ 
+ void* ConstructSUT(ClientData client_data, const char* name, size_t name_length,
+                    IssueQueryCallback issue_cb,
+-                   FlushQueriesCallback flush_queries_cb) {
++                   FlushQueriesCallback flush_queries_cb,
++                   ReportLatencyResultsCallback report_latency_results_cb) {
+   SystemUnderTestTrampoline* sut = new SystemUnderTestTrampoline(
+-      client_data, std::string(name, name_length), issue_cb, flush_queries_cb);
++      client_data, std::string(name, name_length), issue_cb, flush_queries_cb,
++      report_latency_results_cb);
+   return reinterpret_cast<void*>(sut);
+ }
+ 
+diff --git a/loadgen/bindings/c_api.h b/loadgen/bindings/c_api.h
+index 75e6990..af6d5b3 100644
+--- a/loadgen/bindings/c_api.h
++++ b/loadgen/bindings/c_api.h
+@@ -38,6 +38,8 @@ typedef uintptr_t ClientData;
+ 
+ typedef void (*IssueQueryCallback)(ClientData, const QuerySample*, size_t);
+ typedef void (*FlushQueriesCallback)();
++typedef void (*ReportLatencyResultsCallback)(ClientData, const int64_t*,
++                                             size_t);
+ typedef void (*ResponseCallback)(ClientData, QuerySampleResponse*);
+ 
+ /// \brief SUT calls this function to report query result back to loadgen
+@@ -52,7 +54,8 @@ void QuerySamplesCompleteResponseCb(QuerySampleResponse* responses,
+ /// \brief Create an opaque SUT pointer based on C callbacks.
+ void* ConstructSUT(ClientData client_data, const char* name, size_t name_length,
+                    IssueQueryCallback issue_cb,
+-                   FlushQueriesCallback flush_queries_cb);
++                   FlushQueriesCallback flush_queries_cb,
++                   ReportLatencyResultsCallback report_latency_results_cb);
+ /// \brief Destroys the SUT created by ConstructSUT.
+ void DestroySUT(void* sut);
+ 
+diff --git a/loadgen/bindings/python_api.cc b/loadgen/bindings/python_api.cc
+index 345a2a0..2bcf257 100644
+--- a/loadgen/bindings/python_api.cc
++++ b/loadgen/bindings/python_api.cc
+@@ -36,15 +36,19 @@ using IssueQueryCallback = std::function<void(std::vector<QuerySample>)>;
+ using FastIssueQueriesCallback =
+     std::function<void(std::vector<ResponseId>, std::vector<QuerySampleIndex>)>;
+ using FlushQueriesCallback = std::function<void()>;
++using ReportLatencyResultsCallback = std::function<void(std::vector<int64_t>)>;
+ 
+ // Forwards SystemUnderTest calls to relevant callbacks.
+ class SystemUnderTestTrampoline : public SystemUnderTest {
+  public:
+-  SystemUnderTestTrampoline(std::string name, IssueQueryCallback issue_cb,
+-                            FlushQueriesCallback flush_queries_cb)
++  SystemUnderTestTrampoline(
++      std::string name, IssueQueryCallback issue_cb,
++      FlushQueriesCallback flush_queries_cb,
++      ReportLatencyResultsCallback report_latency_results_cb)
+       : name_(std::move(name)),
+         issue_cb_(issue_cb),
+-        flush_queries_cb_(flush_queries_cb) {}
++        flush_queries_cb_(flush_queries_cb),
++        report_latency_results_cb_(report_latency_results_cb) {}
+   ~SystemUnderTestTrampoline() override = default;
+ 
+   const std::string& Name() const override { return name_; }
+@@ -56,18 +60,27 @@ class SystemUnderTestTrampoline : public SystemUnderTest {
+ 
+   void FlushQueries() override { flush_queries_cb_(); }
+ 
++  void ReportLatencyResults(
++      const std::vector<QuerySampleLatency>& latencies_ns) override {
++    pybind11::gil_scoped_acquire gil_acquirer;
++    report_latency_results_cb_(latencies_ns);
++  }
++
+  protected:
+   std::string name_;
+   IssueQueryCallback issue_cb_;
+   FlushQueriesCallback flush_queries_cb_;
++  ReportLatencyResultsCallback report_latency_results_cb_;
+ };
+ 
+ class FastSystemUnderTestTrampoline : public SystemUnderTestTrampoline {
+  public:
+-  FastSystemUnderTestTrampoline(std::string name,
+-                                FastIssueQueriesCallback fast_issue_cb,
+-                                FlushQueriesCallback flush_queries_cb)
+-      : SystemUnderTestTrampoline(name, nullptr, flush_queries_cb),
++  FastSystemUnderTestTrampoline(
++      std::string name, FastIssueQueriesCallback fast_issue_cb,
++      FlushQueriesCallback flush_queries_cb,
++      ReportLatencyResultsCallback report_latency_results_cb)
++      : SystemUnderTestTrampoline(name, nullptr, flush_queries_cb,
++                                  report_latency_results_cb),
+         fast_issue_cb_(fast_issue_cb) {}
+   ~FastSystemUnderTestTrampoline() override = default;
+ 
+@@ -134,9 +147,10 @@ class QuerySampleLibraryTrampoline : public QuerySampleLibrary {
+ namespace py {
+ 
+ uintptr_t ConstructSUT(IssueQueryCallback issue_cb,
+-                       FlushQueriesCallback flush_queries_cb) {
+-  SystemUnderTestTrampoline* sut =
+-      new SystemUnderTestTrampoline("PySUT", issue_cb, flush_queries_cb);
++                       FlushQueriesCallback flush_queries_cb,
++                       ReportLatencyResultsCallback report_latency_results_cb) {
++  SystemUnderTestTrampoline* sut = new SystemUnderTestTrampoline(
++      "PySUT", issue_cb, flush_queries_cb, report_latency_results_cb);
+   return reinterpret_cast<uintptr_t>(sut);
+ }
+ 
+@@ -146,10 +160,12 @@ void DestroySUT(uintptr_t sut) {
+   delete sut_cast;
+ }
+ 
+-uintptr_t ConstructFastSUT(FastIssueQueriesCallback fast_issue_cb,
+-                           FlushQueriesCallback flush_queries_cb) {
++uintptr_t ConstructFastSUT(
++    FastIssueQueriesCallback fast_issue_cb,
++    FlushQueriesCallback flush_queries_cb,
++    ReportLatencyResultsCallback report_latency_results_cb) {
+   FastSystemUnderTestTrampoline* sut = new FastSystemUnderTestTrampoline(
+-      "PyFastSUT", fast_issue_cb, flush_queries_cb);
++      "PyFastSUT", fast_issue_cb, flush_queries_cb, report_latency_results_cb);
+   return reinterpret_cast<uintptr_t>(sut);
+ }
+ 
+diff --git a/loadgen/loadgen.cc b/loadgen/loadgen.cc
+index 6a5a379..1d10543 100644
+--- a/loadgen/loadgen.cc
++++ b/loadgen/loadgen.cc
+@@ -1435,6 +1435,8 @@ void RunPerformanceMode(SystemUnderTest* sut, QuerySampleLibrary* qsl,
+     });
+   }
+ 
++  sut->ReportLatencyResults(pr.sample_latencies);
++
+   PerformanceSummary perf_summary{sut->Name(), settings, std::move(pr)};
+   LogSummary([perf_summary](AsyncSummary& summary) mutable {
+     perf_summary.LogSummary(summary);
+@@ -1527,6 +1529,8 @@ void FindPeakPerformanceMode(SystemUnderTest* sut, QuerySampleLibrary* qsl,
+ #endif
+     });
+ 
++    sut->ReportLatencyResults(base_perf_summary.pr.sample_latencies);
++
+     PerformanceSummary perf_summary{sut->Name(), base_settings,
+                                     std::move(base_perf_summary.pr)};
+     LogSummary([perf_summary](AsyncSummary& summary) mutable {
+@@ -1588,6 +1592,8 @@ void FindPeakPerformanceMode(SystemUnderTest* sut, QuerySampleLibrary* qsl,
+ #endif
+   });
+ 
++  sut->ReportLatencyResults(perf_summary.pr.sample_latencies);
++
+   LogSummary([perf_summary](AsyncSummary& summary) mutable {
+     perf_summary.LogSummary(summary);
+   });
+diff --git a/loadgen/system_under_test.h b/loadgen/system_under_test.h
+index eac7f5f..4b98e06 100644
+--- a/loadgen/system_under_test.h
++++ b/loadgen/system_under_test.h
+@@ -58,6 +58,11 @@ class SystemUnderTest {
+   /// than waiting for some timeout.
+   /// This is especially useful in the server scenario.
+   virtual void FlushQueries() = 0;
++
++  /// \brief Reports the raw latency results to the SUT of each sample issued as
++  /// recorded by the load generator. Units are nanoseconds.
++  virtual void ReportLatencyResults(
++      const std::vector<QuerySampleLatency>& latencies_ns) = 0;
+ };
+ 
+ /// @}
+diff --git a/loadgen/tests/basic.cc b/loadgen/tests/basic.cc
+index 97c6a0b..d5a8b59 100644
+--- a/loadgen/tests/basic.cc
++++ b/loadgen/tests/basic.cc
+@@ -91,6 +91,9 @@ struct SystemUnderTestBasic : public mlperf::QuerySampleLibrary,
+   }
+   virtual void FlushQueriesExt() {}
+ 
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
++
+   virtual void RunTest() {
+     samples_load_count_.resize(total_sample_count_, 0);
+     samples_issue_count_.resize(total_sample_count_, 0);
+diff --git a/loadgen/tests/perftests_null_sut.cc b/loadgen/tests/perftests_null_sut.cc
+index bdcd9d4..3007226 100644
+--- a/loadgen/tests/perftests_null_sut.cc
++++ b/loadgen/tests/perftests_null_sut.cc
+@@ -42,6 +42,8 @@ class SystemUnderTestNull : public mlperf::SystemUnderTest {
+   }
+ 
+   void FlushQueries() override {}
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
+ 
+  private:
+   std::string name_{"NullSUT"};
+@@ -105,6 +107,8 @@ class SystemUnderTestNullStdAsync : public mlperf::SystemUnderTest {
+   }
+ 
+   void FlushQueries() override {}
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
+ 
+  private:
+   std::string name_{"NullStdAsync"};
+@@ -160,6 +164,8 @@ class SystemUnderTestNullPool : public mlperf::SystemUnderTest {
+   }
+ 
+   void FlushQueries() override {}
++  void ReportLatencyResults(
++      const std::vector<mlperf::QuerySampleLatency>& latencies_ns) override {}
+ 
+  private:
+   void WorkerThread() {


### PR DESCRIPTION
this builds well, but doesn't work because the removal of [ReportLatencyResults() in loadgen ](https://github.com/mlcommons/inference/commit/a8a43dcf2ce9f795be637f3126250c1cfa0d736e)

close #435 