### PR TITLE
Refactor `state.dart` (part 1)

### DIFF
--- a/flutter/lib/backend/bridge/ffi_run.dart
+++ b/flutter/lib/backend/bridge/ffi_run.dart
@@ -102,8 +102,8 @@ class _RunOut extends Struct {
   external Pointer<Utf8> backend_vendor;
   external Pointer<Utf8> accelerator_name;
 
-  RunResult toRunResult(DateTime startTime) {
-    return RunResult(
+  NativeRunResult toRunResult(DateTime startTime) {
+    return NativeRunResult(
       accuracy1: accuracy1.address == 0 ? null : accuracy1.ref.toAccuracy(),
       accuracy2: accuracy2.address == 0 ? null : accuracy2.ref.toAccuracy(),
       numSamples: num_samples,
@@ -135,7 +135,7 @@ final _getQuery =
 final _getDatasetSize = getBridgeHandle()
     .lookupFunction<_GetQuery1, _GetQuery2>(_getDatasetSizeName);
 
-RunResult runBenchmark(RunSettings rs) {
+NativeRunResult runBenchmark(RunSettings rs) {
   final startTime = DateTime.now();
 
   var runIn = malloc.allocate<_RunIn>(sizeOf<_RunIn>());

--- a/flutter/lib/backend/bridge/isolate.dart
+++ b/flutter/lib/backend/bridge/isolate.dart
@@ -14,7 +14,7 @@ class _ErrorHolder {
 
 class BridgeIsolate {
   late final SendPort _runSendPort;
-  Completer<RunResult> _nextResult = Completer();
+  Completer<NativeRunResult> _nextResult = Completer();
 
   BridgeIsolate._();
 
@@ -31,7 +31,7 @@ class BridgeIsolate {
         sendPortCompleter.complete(message);
         return;
       }
-      if (message is RunResult) {
+      if (message is NativeRunResult) {
         if (res._nextResult.isCompleted) {
           throw 'unexpected completed run result';
         }
@@ -49,7 +49,7 @@ class BridgeIsolate {
     return res;
   }
 
-  Future<RunResult> run(RunSettings rs) async {
+  Future<NativeRunResult> run(RunSettings rs) async {
     _runSendPort.send(rs);
     try {
       var res = await _nextResult.future;

--- a/flutter/lib/backend/bridge/run_result.dart
+++ b/flutter/lib/backend/bridge/run_result.dart
@@ -1,6 +1,6 @@
 import 'package:mlperfbench_common/data/results/benchmark_result.dart';
 
-class RunResult {
+class NativeRunResult {
   final Accuracy? accuracy1;
   final Accuracy? accuracy2;
   final int numSamples;
@@ -10,7 +10,7 @@ class RunResult {
   final String acceleratorName;
   final DateTime startTime;
 
-  RunResult({
+  NativeRunResult({
     required this.accuracy1,
     required this.accuracy2,
     required this.numSamples,
@@ -22,5 +22,5 @@ class RunResult {
   });
 
   @override
-  String toString() => 'RunResult(accuracy:$accuracy1)';
+  String toString() => 'RunResult(accuracy:$accuracy1, accuracy2:$accuracy2)';
 }

--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -114,7 +114,7 @@ class Benchmark {
       dataset_groundtruth_path: resourceManager.get(dataset.groundtruthPath),
       dataset_offset: taskConfig.model.offset,
       scenario: taskConfig.scenario,
-      mode: runMode.mode,
+      mode: runMode.loadgenMode,
       min_query_count: minQueryCount,
       min_duration: minDuration,
       single_stream_expected_latency_ns:

--- a/flutter/lib/benchmark/run_info.dart
+++ b/flutter/lib/benchmark/run_info.dart
@@ -4,9 +4,9 @@ import 'package:mlperfbench/backend/loadgen_info.dart';
 
 class RunInfo {
   final RunSettings settings;
-  final RunResult result;
+  final NativeRunResult result;
   final LoadgenInfo? loadgenInfo;
-  final double throughput;
+  final double? throughput;
 
   RunInfo({
     required this.settings,

--- a/flutter/lib/benchmark/run_info.dart
+++ b/flutter/lib/benchmark/run_info.dart
@@ -13,5 +13,9 @@ class RunInfo {
     required this.result,
     required this.loadgenInfo,
     required this.throughput,
-  });
+  }) {
+    if (!(throughput?.isFinite ?? true)) {
+      throw 'throughput must be a finite number: $throughput';
+    }
+  }
 }

--- a/flutter/lib/benchmark/run_mode.dart
+++ b/flutter/lib/benchmark/run_mode.dart
@@ -7,35 +7,40 @@ class BenchmarkRunMode {
   static const _perfLogSuffix = 'performance';
   static const _accuracyLogSuffix = 'accuracy';
 
-  final String mode;
-  final String logSuffix;
+  final String loadgenMode;
+  final String readable;
   final pb.OneDatasetConfig Function(pb.TaskConfig taskConfig) chooseDataset;
 
   BenchmarkRunMode._({
-    required this.mode,
-    required this.logSuffix,
+    required this.loadgenMode,
+    required this.readable,
     required this.chooseDataset,
   });
 
   static BenchmarkRunMode performance = BenchmarkRunMode._(
-    mode: _performanceModeString,
-    logSuffix: _perfLogSuffix,
+    loadgenMode: _performanceModeString,
+    readable: _perfLogSuffix,
     chooseDataset: (task) => task.datasets.lite,
   );
   static BenchmarkRunMode accuracy = BenchmarkRunMode._(
-    mode: _accuracyModeString,
-    logSuffix: _accuracyLogSuffix,
+    loadgenMode: _accuracyModeString,
+    readable: _accuracyLogSuffix,
     chooseDataset: (task) => task.datasets.full,
   );
 
   static BenchmarkRunMode performanceTest = BenchmarkRunMode._(
-    mode: _performanceModeString,
-    logSuffix: _perfLogSuffix,
+    loadgenMode: _performanceModeString,
+    readable: _perfLogSuffix,
     chooseDataset: (task) => task.datasets.tiny,
   );
   static BenchmarkRunMode accuracyTest = BenchmarkRunMode._(
-    mode: _accuracyModeString,
-    logSuffix: _accuracyLogSuffix,
+    loadgenMode: _accuracyModeString,
+    readable: _accuracyLogSuffix,
     chooseDataset: (task) => task.datasets.tiny,
   );
+
+  @override
+  String toString() {
+    return readable;
+  }
 }

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -13,9 +13,6 @@ import 'package:wakelock/wakelock.dart';
 
 import 'package:mlperfbench/backend/bridge/isolate.dart';
 import 'package:mlperfbench/backend/list.dart';
-import 'package:mlperfbench/backend/loadgen_info.dart';
-import 'package:mlperfbench/benchmark/info.dart';
-import 'package:mlperfbench/benchmark/run_info.dart';
 import 'package:mlperfbench/board_decoder.dart';
 import 'package:mlperfbench/build_info.dart';
 import 'package:mlperfbench/resources/config_manager.dart';

--- a/flutter/lib/resources/export_result_helper.dart
+++ b/flutter/lib/resources/export_result_helper.dart
@@ -1,4 +1,3 @@
-import 'package:mlperfbench/backend/loadgen_info.dart';
 import 'package:mlperfbench_common/data/results/backend_info.dart';
 import 'package:mlperfbench_common/data/results/backend_settings.dart';
 import 'package:mlperfbench_common/data/results/backend_settings_extra.dart';
@@ -7,6 +6,7 @@ import 'package:mlperfbench_common/data/results/dataset_info.dart';
 
 import 'package:mlperfbench/backend/bridge/run_result.dart';
 import 'package:mlperfbench/backend/list.dart';
+import 'package:mlperfbench/backend/loadgen_info.dart';
 import 'package:mlperfbench/benchmark/benchmark.dart';
 import 'package:mlperfbench/benchmark/run_info.dart';
 import 'package:mlperfbench/benchmark/run_mode.dart';
@@ -76,7 +76,7 @@ class ResultHelper {
     if (source == null) {
       return null;
     }
-    BenchmarkLoadgenInfo(
+    return BenchmarkLoadgenInfo(
       validity: source.validity,
       duration: source.meanLatency * source.queryCount,
     );

--- a/flutter/lib/resources/export_result_helper.dart
+++ b/flutter/lib/resources/export_result_helper.dart
@@ -82,7 +82,7 @@ class ResultHelper {
     );
   }
 
-  BackendReportedInfo _makeBackendInfo(RunResult result) {
+  BackendReportedInfo _makeBackendInfo(NativeRunResult result) {
     return BackendReportedInfo(
       filename: backendInfo.libName,
       backendName: result.backendName,

--- a/flutter/lib/resources/export_result_helper.dart
+++ b/flutter/lib/resources/export_result_helper.dart
@@ -49,13 +49,8 @@ class ResultHelper {
     final result = info.result;
     final dataset = runMode.chooseDataset(benchmark.taskConfig);
 
-    double? throughput = info.throughput;
-    if (!throughput.isFinite) {
-      throughput = null;
-    }
-
     return BenchmarkRunResult(
-      throughput: throughput,
+      throughput: info.throughput,
       accuracy: result.accuracy1,
       accuracy2: result.accuracy2,
       dataset: DatasetInfo(

--- a/flutter/lib/resources/export_result_helper.dart
+++ b/flutter/lib/resources/export_result_helper.dart
@@ -1,0 +1,119 @@
+import 'package:mlperfbench/backend/loadgen_info.dart';
+import 'package:mlperfbench_common/data/results/backend_info.dart';
+import 'package:mlperfbench_common/data/results/backend_settings.dart';
+import 'package:mlperfbench_common/data/results/backend_settings_extra.dart';
+import 'package:mlperfbench_common/data/results/benchmark_result.dart';
+import 'package:mlperfbench_common/data/results/dataset_info.dart';
+
+import 'package:mlperfbench/backend/bridge/run_result.dart';
+import 'package:mlperfbench/backend/list.dart';
+import 'package:mlperfbench/benchmark/benchmark.dart';
+import 'package:mlperfbench/benchmark/run_info.dart';
+import 'package:mlperfbench/benchmark/run_mode.dart';
+import 'package:mlperfbench/protos/backend_setting.pb.dart' as pb;
+
+class ResultHelper {
+  final Benchmark benchmark;
+  final BackendInfo backendInfo;
+
+  ResultHelper({
+    required this.benchmark,
+    required this.backendInfo,
+  });
+
+  BenchmarkExportResult exportResultFromRunInfo({
+    required RunInfo performanceInfo,
+    required RunInfo? accuracyInfo,
+    required BenchmarkRunMode perfMode,
+    required BenchmarkRunMode accuracyMode,
+  }) {
+    return BenchmarkExportResult(
+      benchmarkId: benchmark.id,
+      benchmarkName: benchmark.taskConfig.name,
+      performanceRun: _makeRunResult(performanceInfo, perfMode),
+      accuracyRun: _makeRunResult(accuracyInfo, accuracyMode),
+      minDuration: benchmark.taskConfig.minDuration,
+      minSamples: benchmark.taskConfig.minQueryCount,
+      backendInfo: _makeBackendInfo(performanceInfo.result),
+      backendSettings:
+          _makeBackendSettingsInfo(performanceInfo.settings.backend_settings),
+      loadgenScenario: BenchmarkExportResult.parseLoadgenScenario(
+          benchmark.taskConfig.scenario),
+    );
+  }
+
+  BenchmarkRunResult? _makeRunResult(RunInfo? info, BenchmarkRunMode runMode) {
+    if (info == null) {
+      return null;
+    }
+    final result = info.result;
+    final dataset = runMode.chooseDataset(benchmark.taskConfig);
+
+    double? throughput = info.throughput;
+    if (!throughput.isFinite) {
+      throughput = null;
+    }
+
+    return BenchmarkRunResult(
+      throughput: throughput,
+      accuracy: result.accuracy1,
+      accuracy2: result.accuracy2,
+      dataset: DatasetInfo(
+        name: dataset.name,
+        type: DatasetInfo.parseDatasetType(
+            benchmark.taskConfig.datasets.type.toString()),
+        dataPath: dataset.inputPath,
+        groundtruthPath: dataset.groundtruthPath,
+      ),
+      measuredDuration: result.duration,
+      measuredSamples: result.numSamples,
+      startDatetime: result.startTime,
+      loadgenInfo: _makeLoadgenInfo(info.loadgenInfo),
+    );
+  }
+
+  BenchmarkLoadgenInfo? _makeLoadgenInfo(LoadgenInfo? source) {
+    if (source == null) {
+      return null;
+    }
+    BenchmarkLoadgenInfo(
+      validity: source.validity,
+      duration: source.meanLatency * source.queryCount,
+    );
+  }
+
+  BackendReportedInfo _makeBackendInfo(RunResult result) {
+    return BackendReportedInfo(
+      filename: backendInfo.libName,
+      backendName: result.backendName,
+      vendorName: result.backendVendor,
+      acceleratorName: result.acceleratorName,
+    );
+  }
+
+  BackendSettingsInfo _makeBackendSettingsInfo(pb.SettingList settings) {
+    final taskSettings = settings.benchmarkSetting;
+
+    return BackendSettingsInfo(
+      acceleratorCode: taskSettings.accelerator,
+      acceleratorDesc: taskSettings.acceleratorDesc,
+      framework: taskSettings.framework,
+      modelPath: taskSettings.modelPath,
+      batchSize: taskSettings.batchSize,
+      extraSettings: _extraSettingsFromCommon(settings.setting),
+    );
+  }
+
+  List<BackendExtraSetting> _extraSettingsFromCommon(
+      List<pb.Setting> commonSettings) {
+    final list = <BackendExtraSetting>[];
+    for (var item in commonSettings) {
+      list.add(BackendExtraSetting(
+          id: item.id,
+          name: item.name,
+          value: item.value.value,
+          valueName: item.value.name));
+    }
+    return list;
+  }
+}

--- a/flutter/lib/resources/validation_helper.dart
+++ b/flutter/lib/resources/validation_helper.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+
+import 'package:mlperfbench/benchmark/benchmark.dart';
+import 'package:mlperfbench/benchmark/run_mode.dart';
+import 'package:mlperfbench/resources/resource_manager.dart';
+import 'package:mlperfbench/resources/utils.dart';
+
+class ValidationHelper {
+  final ResourceManager resourceManager;
+  final BenchmarkList middle;
+  final List<BenchmarkRunMode> selectedRunModes;
+
+  ValidationHelper({
+    required this.resourceManager,
+    required this.middle,
+    required this.selectedRunModes,
+  });
+
+  Future<String> validateExternalResourcesDirectory(
+      String errorDescription) async {
+    final dataFolderPath = resourceManager.getDataFolder();
+    if (dataFolderPath.isEmpty) {
+      return 'Data folder must not be empty';
+    }
+    if (!await Directory(dataFolderPath).exists()) {
+      return 'Data folder does not exist';
+    }
+    final resources =
+        middle.listResources(modes: selectedRunModes, skipInactive: true);
+    final missing = await resourceManager.validateResourcesExist(resources);
+    if (missing.isEmpty) return '';
+
+    return errorDescription +
+        missing.mapIndexed((i, element) => '\n${i + 1}) $element').join();
+  }
+
+  Future<String> validateOfflineMode(String errorDescription) async {
+    final resources =
+        middle.listResources(modes: selectedRunModes, skipInactive: true);
+    final internetResources = filterInternetResources(resources);
+    if (internetResources.isEmpty) return '';
+
+    return errorDescription +
+        internetResources
+            .mapIndexed((i, element) => '\n${i + 1}) $element')
+            .join();
+  }
+}

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -1,0 +1,295 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:async/async.dart';
+import 'package:mlperfbench_common/data/extended_result.dart';
+import 'package:mlperfbench_common/data/meta_info.dart';
+import 'package:mlperfbench_common/data/results/benchmark_result.dart';
+import 'package:uuid/uuid.dart';
+import 'package:worker_manager/worker_manager.dart';
+
+import 'package:mlperfbench/app_constants.dart';
+import 'package:mlperfbench/backend/bridge/isolate.dart';
+import 'package:mlperfbench/backend/list.dart';
+import 'package:mlperfbench/backend/loadgen_info.dart';
+import 'package:mlperfbench/benchmark/benchmark.dart';
+import 'package:mlperfbench/benchmark/info.dart';
+import 'package:mlperfbench/benchmark/run_info.dart';
+import 'package:mlperfbench/benchmark/run_mode.dart';
+import 'package:mlperfbench/build_info.dart';
+import 'package:mlperfbench/device_info.dart';
+import 'package:mlperfbench/protos/backend_setting.pb.dart' as pb;
+import 'package:mlperfbench/resources/export_result_helper.dart';
+import 'package:mlperfbench/resources/resource_manager.dart';
+import 'package:mlperfbench/store.dart';
+
+class ProgressInfo {
+  bool cooldown = false;
+  bool accuracy = false;
+  BenchmarkInfo? info;
+  int totalStages = 0;
+  int currentStage = 0;
+  double cooldownDuration = 0;
+  double get stageProgress => calculateStageProgress?.call() ?? 0.0;
+
+  double Function()? calculateStageProgress;
+}
+
+class TaskRunner {
+  final Store store;
+  final void Function() notifyListeners;
+  final ResourceManager resourceManager;
+  final BridgeIsolate backendBridge;
+  final BackendInfo backendInfo;
+
+  ProgressInfo progressInfo = ProgressInfo();
+  bool _aborting = false;
+  Future<void> _cooldownFuture = Future.value();
+
+  TaskRunner({
+    required this.store,
+    required this.notifyListeners,
+    required this.resourceManager,
+    required this.backendBridge,
+    required this.backendInfo,
+  });
+
+  BenchmarkRunMode get perfMode => store.testMode
+      ? BenchmarkRunMode.performanceTest
+      : BenchmarkRunMode.performance;
+
+  BenchmarkRunMode get accuracyMode => store.testMode
+      ? BenchmarkRunMode.accuracyTest
+      : BenchmarkRunMode.accuracy;
+
+  List<BenchmarkRunMode> get selectedRunModes {
+    final result = <BenchmarkRunMode>[];
+    result.add(perfMode);
+    if (store.submissionMode) {
+      result.add(accuracyMode);
+    }
+    return result;
+  }
+
+  Future<void> abortBenchmarks() async {
+    _aborting = true;
+    await CancelableOperation.fromFuture(_cooldownFuture).cancel();
+    notifyListeners();
+  }
+
+  Future<ExtendedResult?> runBenchmarks(
+      BenchmarkList middle, String currentLogDir) async {
+    final cooldown = store.cooldown;
+    final cooldownPause = store.testMode || isFastMode
+        ? const Duration(seconds: 1)
+        : Duration(minutes: store.cooldownDuration);
+
+    final activeBenchmarks =
+        middle.benchmarks.where((element) => element.isActive);
+
+    final exportResults = <BenchmarkExportResult>[];
+    var first = true;
+
+    progressInfo.totalStages = activeBenchmarks.length;
+    if (store.submissionMode) {
+      progressInfo.totalStages += activeBenchmarks.length;
+    }
+    progressInfo.currentStage = 0;
+    progressInfo.cooldownDuration = cooldownPause.inSeconds.toDouble();
+
+    for (final benchmark in activeBenchmarks) {
+      progressInfo.info = benchmark.info;
+
+      // increment counter for performance benchmark before cooldown
+      progressInfo.currentStage++;
+
+      if (_aborting) break;
+
+      // we only do cooldown before performance benchmarks
+      if (cooldown && !first) {
+        progressInfo.cooldown = true;
+        final timer = Stopwatch()..start();
+        progressInfo.calculateStageProgress = () {
+          return timer.elapsed.inSeconds / progressInfo.cooldownDuration;
+        };
+        notifyListeners();
+        await (_cooldownFuture = Future.delayed(cooldownPause));
+        progressInfo.cooldown = false;
+        timer.stop();
+      }
+      first = false;
+      if (_aborting) break;
+
+      final perfTimer = Stopwatch()..start();
+      progressInfo.accuracy = false;
+      progressInfo.calculateStageProgress = () {
+        // UI updates once per second so using 1 second as lower bound should not affect it.
+        final minDuration = max(benchmark.taskConfig.minDuration, 1);
+        final timeProgress = perfTimer.elapsedMilliseconds /
+            Duration.millisecondsPerSecond /
+            minDuration;
+
+        final minQueries = max(benchmark.taskConfig.minQueryCount, 1);
+        final queryCounter = backendBridge.getQueryCounter();
+        final queryProgress =
+            queryCounter < 0 ? 1.0 : queryCounter / minQueries;
+        return min(timeProgress, queryProgress);
+      };
+      notifyListeners();
+      final performanceRunInfo = await runBenchmark(
+        benchmark,
+        perfMode,
+        backendInfo.settings.commonSetting,
+        backendInfo.libName,
+        currentLogDir,
+      );
+      perfTimer.stop();
+      performanceRunInfo.loadgenInfo!;
+
+      final performanceResult = performanceRunInfo.result;
+      benchmark.performanceModeResult = BenchmarkResult(
+        throughput: performanceRunInfo.throughput,
+        accuracy: performanceResult.accuracy1,
+        accuracy2: performanceResult.accuracy2,
+        backendName: performanceResult.backendName,
+        acceleratorName: performanceResult.acceleratorName,
+        batchSize: benchmark.benchmarkSettings.batchSize,
+        validity: performanceRunInfo.loadgenInfo!.validity,
+      );
+
+      if (_aborting) break;
+
+      RunInfo? accuracyRunInfo;
+
+      if (store.submissionMode) {
+        progressInfo.currentStage++;
+        progressInfo.accuracy = true;
+        progressInfo.calculateStageProgress = () {
+          final queryCounter = backendBridge.getQueryCounter();
+          final queryProgress = queryCounter < 0
+              ? 1.0
+              : queryCounter / backendBridge.getDatasetSize();
+          return queryProgress;
+        };
+        notifyListeners();
+        accuracyRunInfo = await runBenchmark(
+          benchmark,
+          accuracyMode,
+          backendInfo.settings.commonSetting,
+          backendInfo.libName,
+          currentLogDir,
+        );
+
+        final accuracyResult = accuracyRunInfo.result;
+        benchmark.accuracyModeResult = BenchmarkResult(
+          // loadgen doesn't calculate latency for accuracy mode benchmarks
+          // so throughput is infinity which is not a valid JSON numeric value
+          throughput: 0.0,
+          accuracy: accuracyResult.accuracy1,
+          accuracy2: accuracyResult.accuracy2,
+          backendName: accuracyResult.backendName,
+          acceleratorName: accuracyResult.acceleratorName,
+          batchSize: benchmark.benchmarkSettings.batchSize,
+          validity: false,
+        );
+      }
+
+      final resultHelper = ResultHelper(
+        benchmark: benchmark,
+        backendInfo: backendInfo,
+      );
+
+      exportResults.add(resultHelper.exportResultFromRunInfo(
+        performanceInfo: performanceRunInfo,
+        accuracyInfo: accuracyRunInfo,
+        perfMode: perfMode,
+        accuracyMode: accuracyMode,
+      ));
+    }
+
+    if (_aborting) {
+      _aborting = false;
+      return null;
+    }
+    return ExtendedResult(
+      meta: ResultMetaInfo(uuid: const Uuid().v4()),
+      environmentInfo: DeviceInfo.instance.envInfo,
+      results: exportResults,
+      buildInfo: BuildInfoHelper.info,
+    );
+  }
+
+  void _doSomethingCPUIntensive(double value, TypeSendPort port) {
+    var newValue = value;
+    while (true) {
+      newValue = newValue * 0.999999999999999;
+    }
+  }
+
+  Future<RunInfo> runBenchmark(
+    Benchmark benchmark,
+    BenchmarkRunMode runMode,
+    List<pb.Setting> commonSettings,
+    String backendLibName,
+    String logDir,
+  ) async {
+    print('Running ${benchmark.id} in ${runMode.mode} mode...');
+    final stopwatch = Stopwatch()..start();
+
+    logDir = '$logDir/${benchmark.id}-${runMode.logSuffix}';
+    await Directory(logDir).create(recursive: true);
+
+    final runSettings = benchmark.createRunSettings(
+      runMode: runMode,
+      resourceManager: resourceManager,
+      commonSettings: commonSettings,
+      backendLibName: backendLibName,
+      logDir: logDir,
+      isTestMode: store.testMode,
+    );
+
+    if (store.artificialCPULoadEnabled) {
+      print('Apply the artificial CPU load for ${benchmark.taskConfig.id}');
+      const value = 999999999999999.0;
+      final _ = Executor().execute(arg1: value, fun1: _doSomethingCPUIntensive);
+    }
+
+    final result = await backendBridge.run(runSettings);
+    final elapsed = stopwatch.elapsed;
+
+    if (store.artificialCPULoadEnabled) {
+      await Executor().dispose();
+    }
+
+    if (!(result.accuracy1?.isInBounds() ?? true) ||
+        !(result.accuracy2?.isInBounds() ?? true)) {
+      print(
+          '${benchmark.id} accuracies: ${result.accuracy1}, ${result.accuracy2}');
+      throw '${benchmark.info.taskName}: ${runMode.logSuffix} run: accuracy is invalid (backend may be corrupted)';
+    }
+
+    const logFileName = 'mlperf_log_detail.txt';
+    final loadgenInfo = await LoadgenInfo.fromFile(
+      filepath: '$logDir/$logFileName',
+    );
+
+    double throughput;
+    if (loadgenInfo == null) {
+      throughput = 0.0;
+    } else if (benchmark.info.isOffline) {
+      throughput = result.numSamples / loadgenInfo.latency90;
+    } else {
+      throughput = 1.0 / loadgenInfo.latency90;
+    }
+
+    print(
+        'Run result: id: ${benchmark.id}, $result, throughput: $throughput, elapsed: $elapsed');
+
+    return RunInfo(
+      settings: runSettings,
+      result: result,
+      loadgenInfo: loadgenInfo,
+      throughput: throughput,
+    );
+  }
+}

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -276,7 +276,7 @@ class _NativeRunHelper {
       return await _invokeNativeRun();
     } finally {
       if (artificialLoadHandle != null) {
-        artificialLoadHandle.cancel();
+        await Executor().dispose();
       }
     }
   }

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -45,7 +45,7 @@ class TaskRunner {
   final BackendInfo backendInfo;
 
   ProgressInfo progressInfo = ProgressInfo();
-  bool _aborting = false;
+  bool aborting = false;
   Future<void> _cooldownFuture = Future.value();
 
   TaskRunner({
@@ -74,7 +74,7 @@ class TaskRunner {
   }
 
   Future<void> abortBenchmarks() async {
-    _aborting = true;
+    aborting = true;
     await CancelableOperation.fromFuture(_cooldownFuture).cancel();
     notifyListeners();
   }
@@ -105,7 +105,7 @@ class TaskRunner {
       // increment counter for performance benchmark before cooldown
       progressInfo.currentStage++;
 
-      if (_aborting) break;
+      if (aborting) break;
 
       // we only do cooldown before performance benchmarks
       if (cooldown && !first) {
@@ -120,7 +120,7 @@ class TaskRunner {
         timer.stop();
       }
       first = false;
-      if (_aborting) break;
+      if (aborting) break;
 
       final perfTimer = Stopwatch()..start();
       progressInfo.accuracy = false;
@@ -164,7 +164,7 @@ class TaskRunner {
         validity: performanceRunInfo.loadgenInfo!.validity,
       );
 
-      if (_aborting) break;
+      if (aborting) break;
 
       RunInfo? accuracyRunInfo;
 
@@ -218,8 +218,8 @@ class TaskRunner {
       ));
     }
 
-    if (_aborting) {
-      _aborting = false;
+    if (aborting) {
+      aborting = false;
       return null;
     }
     return ExtendedResult(

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -2,8 +2,6 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:async/async.dart';
-import 'package:mlperfbench/backend/bridge/run_result.dart';
-import 'package:mlperfbench/backend/bridge/run_settings.dart';
 import 'package:mlperfbench_common/data/extended_result.dart';
 import 'package:mlperfbench_common/data/meta_info.dart';
 import 'package:mlperfbench_common/data/results/benchmark_result.dart';
@@ -12,6 +10,8 @@ import 'package:worker_manager/worker_manager.dart';
 
 import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/backend/bridge/isolate.dart';
+import 'package:mlperfbench/backend/bridge/run_result.dart';
+import 'package:mlperfbench/backend/bridge/run_settings.dart';
 import 'package:mlperfbench/backend/list.dart';
 import 'package:mlperfbench/backend/loadgen_info.dart';
 import 'package:mlperfbench/benchmark/benchmark.dart';

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -268,7 +268,8 @@ class _NativeRunHelper {
     if (enableArtificialLoad) {
       print('Apply the artificial CPU load for ${benchmark.taskConfig.id}');
       const value = 999999999999999.0;
-      artificialLoadHandle = Executor().execute(arg1: value, fun1: _doSomethingCPUIntensive);
+      artificialLoadHandle =
+          Executor().execute(arg1: value, fun1: _doSomethingCPUIntensive);
     }
 
     try {
@@ -288,13 +289,15 @@ class _NativeRunHelper {
     final nativeResult = await backendBridge.run(runSettings);
     final elapsed = stopwatch.elapsed;
     print('$logPrefix: elapsed: $elapsed');
+    print('$logPrefix: result: $nativeResult');
 
     if (!_checkAccuracy(nativeResult)) {
       throw '$logPrefix: accuracy is invalid (backend may be corrupted)';
     }
 
     final runInfo = await _makeRunInfo(nativeResult);
-    print('$logPrefix: $nativeResult, throughput: ${runInfo.throughput}');
+    print('$logPrefix: throughput: ${runInfo.throughput}');
+
     return runInfo;
   }
 

--- a/flutter/lib/ui/root/main_screen.dart
+++ b/flutter/lib/ui/root/main_screen.dart
@@ -111,8 +111,9 @@ class MyHomePage extends StatelessWidget {
       child: GoButtonGradient(() async {
         // TODO (anhappdev) Refactor the code here to avoid duplicated code.
         // The checks before calling state.runBenchmarks() in main_screen and result_screen are similar.
-        final wrongPathError = await state.validateExternalResourcesDirectory(
-            stringResources.dialogContentMissingFiles);
+        final wrongPathError = await state.validator
+            .validateExternalResourcesDirectory(
+                stringResources.dialogContentMissingFiles);
         if (wrongPathError.isNotEmpty) {
           // TODO (anhappdev): Uncomment the if line and remove the ignore line, when updated to Flutter v3.4.
           // See https://github.com/flutter/flutter/issues/111488
@@ -122,7 +123,7 @@ class MyHomePage extends StatelessWidget {
           return;
         }
         if (store.offlineMode) {
-          final offlineError = await state
+          final offlineError = await state.validator
               .validateOfflineMode(stringResources.dialogContentOfflineWarning);
           if (offlineError.isNotEmpty) {
             // TODO (anhappdev): Uncomment the if line and remove the ignore line, when updated to Flutter v3.4.

--- a/flutter/lib/ui/run/progress_screen.dart
+++ b/flutter/lib/ui/run/progress_screen.dart
@@ -28,7 +28,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
   Widget build(BuildContext context) {
     final state = context.watch<BenchmarkState>();
     final l10n = AppLocalizations.of(context);
-    final progress = state.progressInfo;
+    final progress = state.taskRunner.progressInfo;
 
     final backgroundGradient = BoxDecoration(
       gradient: LinearGradient(
@@ -157,7 +157,7 @@ class _ProgressScreenState extends State<ProgressScreen> {
             ),
           ),
         ),
-        onPressed: () async => await state.abortBenchmarks(),
+        onPressed: () async => await state.taskRunner.abortBenchmarks(),
         child: Padding(
           padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
           child: Text(

--- a/flutter/lib/ui/run/result_screen.dart
+++ b/flutter/lib/ui/run/result_screen.dart
@@ -344,8 +344,8 @@ class _ResultScreenState extends State<ResultScreen>
             onPressed: () async {
               // TODO (anhappdev) Refactor the code here to avoid duplicated code.
               // The checks before calling state.runBenchmarks() in main_screen and result_screen are similar.
-              final wrongPathError =
-                  await state.validateExternalResourcesDirectory(
+              final wrongPathError = await state.validator
+                  .validateExternalResourcesDirectory(
                       stringResources.dialogContentMissingFiles);
               if (wrongPathError.isNotEmpty) {
                 if (!mounted) return;
@@ -353,7 +353,7 @@ class _ResultScreenState extends State<ResultScreen>
                 return;
               }
               if (store.offlineMode) {
-                final offlineError = await state.validateOfflineMode(
+                final offlineError = await state.validator.validateOfflineMode(
                     stringResources.dialogContentOfflineWarning);
                 if (offlineError.isNotEmpty) {
                   if (!mounted) return;


### PR DESCRIPTION
Part of https://github.com/mlcommons/mobile_app_open/issues/556

In this PR I extract several helper classes from `BenchmarkState`: `TaskRunner`, `ResultHelper`, `ValidationHelper`.

Overall the layout of classes and methods is still suboptimal, but I want to merge this now to reduce possible merge issues.
I have already done manual merge/rebase ~~3 times~~ 4 times because literally any changes to `state.dart` in other PRs require manual merge with this one. And almost any changes in the app require a change in the `state.dart`.