### PR TITLE
Revert passing accelerator_desc to backend

### DIFF
--- a/flutter/cpp/c/type.h
+++ b/flutter/cpp/c/type.h
@@ -47,7 +47,6 @@ typedef struct {
 const int kMaxMLPerfBackendConfigs = 256;
 typedef struct {
   const char* accelerator;
-  const char* accelerator_desc;
   uint32_t batch_size;
   int count = 0;
   const char* keys[kMaxMLPerfBackendConfigs];

--- a/flutter/cpp/utils.cc
+++ b/flutter/cpp/utils.cc
@@ -91,7 +91,6 @@ bool AddBackendConfiguration(mlperf_backend_configuration_t *configs,
 
 void DeleteBackendConfiguration(mlperf_backend_configuration_t *configs) {
   delete configs->accelerator;
-  delete configs->accelerator_desc;
   for (int i = 0; i < configs->count; ++i) {
     delete configs->keys[i];
     delete configs->values[i];
@@ -106,10 +105,6 @@ mlperf_backend_configuration_t CppToCSettings(const SettingList &settings) {
   strcpy(accelerator, settings.benchmark_setting().accelerator().c_str());
   c_settings.accelerator = accelerator;
   c_settings.batch_size = settings.benchmark_setting().batch_size();
-  char *accelerator_desc =
-      new char[settings.benchmark_setting().accelerator_desc().length() + 1];
-  strcpy(accelerator_desc, settings.benchmark_setting().accelerator_desc().c_str());
-  c_settings.accelerator_desc = accelerator_desc;
 
   // Add common settings
   for (Setting s : settings.setting()) {

--- a/mobile_back_qti/cpp/backend_qti/mlperf_helper.h
+++ b/mobile_back_qti/cpp/backend_qti/mlperf_helper.h
@@ -31,7 +31,7 @@ static void process_config(const mlperf_backend_configuration_t *configs,
   backend_data->loadOffTime_ = 2;
   backend_data->loadOnTime_ = 100;
   backend_data->useIonBuffers_ = true;
-  backend_data->acceleratorName_=configs->accelerator_desc;
+  backend_data->acceleratorName_=configs->accelerator;
 
   std::string &delegate = backend_data->delegate_;
   delegate = configs->accelerator;


### PR DESCRIPTION
This PR reverts the change, where the field `accelerator_desc` is added to `mlperf_backend_configuration_t` and passed to the backend.
This field was only used (and added) by QTI, so this PR should not impact other backends. For QTI I also provide a quick fix (see review comment).
Per https://github.com/mlcommons/mobile_app_open/pull/566#issuecomment-1302787622