### PR TITLE
enable raw rgb support in snu_sr

### DIFF
--- a/flutter/cpp/datasets/snu_sr.cc
+++ b/flutter/cpp/datasets/snu_sr.cc
@@ -56,7 +56,7 @@ SNUSR::SNUSR(Backend *backend, const std::string &image_dir,
       image_list_.size());
   // Finds all ground truth files under ground_truth_dir.
 
-  std::unordered_set<std::string> gt_exts{".raw", ".jpg", ".jpeg"};
+  std::unordered_set<std::string> gt_exts{".rgb8", ".jpg", ".jpeg"};
   ground_truth_list_ = GetSortedFileNames(ground_truth_dir, gt_exts);
   if (ground_truth_list_.empty()) {
     LOG(ERROR) << "Failed to list all the ground truth files in provided path. "


### PR DESCRIPTION
# Using jpeg for super-resolution results in lower PSNR than using PNG
Why?
* when "traditional" (dct-based) lossy jgp is used, there is information / entropy loss
* the jpeg decoder (from TensorFlow) we use now doesn't support lossless jpeg
* supporting raw rgb is relatively easier than adding png decoder support

# How to convert png to raw rgb

I use ImageMagick.
in the directory with HR png files, 
```
for a in *.png;do base=`basename $a .png`; convert $a ../HR_raw/${base}'.rgb'; mv ../HR_raw/${base}'.rgb' ../HR_raw/${base}'.rgb8'  ;done

```
in the directory with LR png files, 
```
for a in *.png;do base=`basename $a .png`; convert $a ../LR_raw/${base}'.rgb'; mv ../LR_raw/${base}'.rgb' ../LR_raw/${base}'.rgb8'  ;done
```

# Test on devices supporting NNAPI
I pushed `HR_raw` and `LR_raw` to `/data/local/tmp/sr/dataset/`

Then I can get quantized int8 accuracy by 
```
$ adb shell /data/local/tmp/sr/main_sr_raw external snusr --mode=AccuracyOnly   --output_dir=/data/local/tmp/sr_output   --model_file=/data/local/tmp/sr/tflite/pl_f32b5_int8.tflite   --images_directory=/data/local/tmp/sr/dataset/LR_raw  --ground_truth_directory=/data/local/tmp/sr/dataset/HR_raw   --lib_path=/data/local/tmp/sr/libtflitebackend.so

```
or  float16 accuracy by
```
$ adb shell /data/local/tmp/sr/main_sr_raw external snusr --mode=AccuracyOnly   --output_dir=/data/local/tmp/sr_output   --model_file=/data/local/tmp/sr/tflite/pl_f32b5.tflite   --images_directory=/data/local/tmp/sr/dataset/LR_raw  --ground_truth_directory=/data/local/tmp/sr/dataset/HR_raw   --lib_path=/data/local/tmp/sr/libtflitebackend.so
```

|model | PSNR|
|-- | --:|
|f32b5 fp32 (running w/ fp16) | 33.60|
|f32b5_qint8 | 33.52|

```