### PR TITLE
ui: show selected data folder in task config screen

### DIFF
--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -65,6 +65,7 @@
   "settingsTaskDataFolderDefault": "Default",
   "settingsTaskDataFolderApp": "Application folder",
   "settingsTaskDataFolderCustom": "Custom folder",
+  "settingsTaskDataFolderSelected": "Selected data folder",
   "settingsTaskDataFolderWarning": "Folder <path> does not exist or is not accessible",
   "settingsTaskCacheFolderTitle": "Cache folder",
   "settingsTaskCacheFolderDesc": "Cache folder contains downloadable data.\nThis folder can only be changed during build.",

--- a/flutter/lib/ui/settings/task_config_screen.dart
+++ b/flutter/lib/ui/settings/task_config_screen.dart
@@ -233,28 +233,35 @@ class TaskConfigScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final store = context.watch<Store>();
+    final state = context.watch<BenchmarkState>();
+    List<Widget> items = [];
+    items.addAll(_configs.map((c) => getOptionPattern(
+          context,
+          c,
+          store.chosenConfigurationName,
+        )));
+    // On ios you need to properly request access to a folder outside of the app folder
+    // but file_picker plugin doesn't do it.
+    // see the following link for details:
+    // https://github.com/mlcommons/mobile_app_open/pull/562#discussion_r992167655
+    if (!Platform.isIOS) {
+      items.addAll([
+        _makeCacheFolderNotice(l10n),
+        _DataFolderSelectorHelper(context).build(),
+        const Divider(),
+        ListTile(
+            title: Text(l10n.settingsTaskDataFolderSelected),
+            subtitle: Text(state.resourceManager.getDataFolder())),
+        const Divider(),
+      ]);
+    }
 
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.settingsTaskConfigTitle),
       ),
       body: ListView(
-        children: [
-          // On ios you need to properly request access to a folder outside of the app folder
-          // but file_picker plugin doesn't do it.
-          // see the following link for details:
-          //    https://github.com/mlcommons/mobile_app_open/pull/562#discussion_r992167655
-          if (!Platform.isIOS) ...[
-            _makeCacheFolderNotice(l10n),
-            _DataFolderSelectorHelper(context).build(),
-            const Divider(),
-          ],
-          ..._configs.map((c) => getOptionPattern(
-                context,
-                c,
-                store.chosenConfigurationName,
-              )),
-        ],
+        children: items,
       ),
     );
   }


### PR DESCRIPTION
This PR shows the concrete location of the `application folder` in task configuration screen.

<details>
<summary>Click to show the old UI</summary>
 
![Screenshot_1669947596](https://user-images.githubusercontent.com/85728587/205200507-1fe0dedc-6ff9-4d7c-a095-6e2e7d5a99ac.png)

</details>

<details>
<summary>Click to show the new UI</summary>
 
![Screenshot_1669947521](https://user-images.githubusercontent.com/85728587/205200543-212249e4-4f6b-429d-932e-aaa072166a5c.png)

</details>

