### PR TITLE
fix: add missing build number arg in build script

### DIFF
--- a/flutter/android/android.mk
+++ b/flutter/android/android.mk
@@ -68,7 +68,10 @@ flutter_android_apk_release_path=${FLUTTER_ANDROID_APK_FOLDER}/${FLUTTER_ANDROID
 .PHONY: flutter/android/apk
 flutter/android/apk:
 	mkdir -p $$(dirname ${flutter_android_apk_release_path})
-	cd flutter && ${_start_args} flutter --no-version-check build apk ${flutter_official_build_arg} ${flutter_folder_args}
+	cd flutter && ${_start_args} flutter --no-version-check build apk \
+		${flutter_official_build_arg} \
+		${flutter_build_number_arg} \
+		${flutter_folder_args}
 	cp -f flutter/build/app/outputs/flutter-apk/app-release.apk ${flutter_android_apk_release_path}
 
 FLUTTER_ANDROID_APK_TEST_MAIN?=test-main.apk

--- a/flutter/flutter.mk
+++ b/flutter/flutter.mk
@@ -46,6 +46,8 @@ FLUTTER_BUILD_NUMBER?=0
 flutter_build_number_arg=--build-number ${FLUTTER_BUILD_NUMBER}
 .PHONY: flutter/check/build-number
 flutter/check/build-number:
+	@echo FLUTTER_APP_VERSION=${FLUTTER_APP_VERSION}
+	@echo FLUTTER_BUILD_NUMBER=${FLUTTER_BUILD_NUMBER}
 	@[ -n "$$FLUTTER_BUILD_NUMBER" ] \
 		|| (echo FLUTTER_BUILD_NUMBER env must be explicitly set; exit 1)
 

--- a/flutter/ios/ci_scripts/ci_post_clone.sh
+++ b/flutter/ios/ci_scripts/ci_post_clone.sh
@@ -114,7 +114,7 @@ if [ $runner = $XCODE_CLOUD ]; then
   if [ "$CI_XCODEBUILD_ACTION" = "build-for-testing" ]; then
     cd "$MC_REPO_HOME"/flutter && flutter build ios --config-only integration_test/first_test.dart
   else
-    cd "$MC_REPO_HOME"/flutter && flutter build ios --config-only --dart-define=official-build="$OFFICIAL_BUILD"
+    cd "$MC_REPO_HOME"/flutter && flutter build ios --config-only --dart-define=official-build="$OFFICIAL_BUILD" --build-number "$CI_BUILD_NUMBER"
   fi
 fi
 

--- a/flutter/ios/ios.mk
+++ b/flutter/ios/ios.mk
@@ -48,6 +48,6 @@ flutter/ios/ipa:
 	cd flutter && flutter --no-version-check build \
 		ipa \
 		${flutter_official_build_arg} \
-		--build-number ${FLUTTER_BUILD_NUMBER}
+		${flutter_build_number_arg}
 	mkdir -p output/flutter/ios/
 	cp -rf flutter/build/ios/archive/Runner.xcarchive output/flutter/ios/release.xcarchive

--- a/flutter/windows/windows.mk
+++ b/flutter/windows/windows.mk
@@ -63,7 +63,10 @@ flutter/windows/release/copy-dlls:
 .PHONY: flutter/windows/release/build
 flutter/windows/release/build:
 	rm -rf flutter/build/windows/runner/Release
-	cd flutter && ${_start_args} flutter --no-version-check build windows ${flutter_official_build_arg} ${flutter_folder_args}
+	cd flutter && ${_start_args} flutter --no-version-check build windows \
+		${flutter_official_build_arg} \
+		${flutter_build_number_arg} \
+		${flutter_folder_args}
 
 .PHONY: flutter/windows/release/name
 flutter/windows/release/name:


### PR DESCRIPTION
This PR adds the missing build number argument in some build commands.