### PR TITLE
feat: store result of each benchmark run in a separated JSON file

### DIFF
--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -43,9 +43,7 @@ Future<ExtendedResult> obtainResult() async {
   final applicationDirectory =
       await resource_manager.ResourceManager.getApplicationDirectory();
 
-  final rm = result_manager.ResultManager(applicationDirectory);
-  await rm.init();
-
+  final rm = await result_manager.ResultManager.create(applicationDirectory);
   return rm.getLastResult();
 }
 

--- a/flutter/lib/resources/resource_manager.dart
+++ b/flutter/lib/resources/resource_manager.dart
@@ -152,8 +152,7 @@ class ResourceManager {
     await Directory(_loadedResourcesDir).create();
 
     cacheManager = CacheManager(_loadedResourcesDir);
-    resultManager = ResultManager(applicationDirectory);
-    await resultManager.init();
+    resultManager = await ResultManager.create(applicationDirectory);
   }
 
   Future<List<String>> validateResourcesExist(List<Resource> resources) async {

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -62,13 +62,13 @@ class ResultManager {
     }
   }
 
-  Future<void> saveResult(ExtendedResult value) async {
-    results.add(value);
+  Future<void> saveResult(ExtendedResult result) async {
+    results.add(result);
     final DateFormat formatter = DateFormat('yyyy-MM-dd_HHmmss');
-    final String formatted = formatter.format(DateTime.now());
-    final filename = '${_resultsDir.path}/${formatted}_${value.meta.uuid}.json';
+    final String datetime = formatter.format(result.meta.creationDate);
+    final filename = '${_resultsDir.path}/${datetime}_${result.meta.uuid}.json';
     final jsonFile = File(filename);
-    await jsonFile.writeAsString(jsonToStringIndented(value));
+    await jsonFile.writeAsString(jsonToStringIndented(result));
     print('Result saved to $jsonFile');
   }
 

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -64,7 +64,7 @@ class ResultManager {
 
   Future<void> saveResult(ExtendedResult result) async {
     results.add(result);
-    final DateFormat formatter = DateFormat('yyyy-MM-dd_HHmmss');
+    final DateFormat formatter = DateFormat('yyyy-MM-ddTHH-mm-ss');
     final String datetime = formatter.format(result.meta.creationDate);
     final filename = '${_resultsDir.path}/${datetime}_${result.meta.uuid}.json';
     final jsonFile = File(filename);

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -9,9 +9,10 @@ import 'package:mlperfbench/benchmark/benchmark.dart';
 import 'utils.dart';
 
 class ResultManager {
+  List<ExtendedResult> results = [];
+
   static const _resultsDirName = 'results';
   final Directory _resultsDir;
-  List<ExtendedResult> results = [];
   final List<File> _resultsFiles = [];
 
   ResultManager(String applicationDirectory)
@@ -33,7 +34,7 @@ class ResultManager {
         results.add(ExtendedResult.fromJson(json));
         _resultsFiles.add(file);
       } catch (e, trace) {
-        print('unable to parse result from file [$file]: $e');
+        print('Unable to parse result from [$file]: $e');
         print(trace);
       }
     }
@@ -60,6 +61,7 @@ class ResultManager {
     final String formatted = formatter.format(DateTime.now());
     final jsonFile = File('${_resultsDir.path}/$formatted.json');
     await jsonFile.writeAsString(jsonToStringIndented(value));
+    print('Result saved to $jsonFile');
   }
 
   ExtendedResult getLastResult() {

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -9,16 +9,23 @@ import 'package:mlperfbench/benchmark/benchmark.dart';
 import 'utils.dart';
 
 class ResultManager {
-  List<ExtendedResult> results = [];
-
   static const _resultsDirName = 'results';
-  final Directory _resultsDir;
-  final List<File> _resultsFiles = [];
 
-  ResultManager(String applicationDirectory)
-      : _resultsDir = Directory('$applicationDirectory/$_resultsDirName');
+  static Future<ResultManager> create(String applicationDirectory) async {
+    var resultManager = ResultManager._create(applicationDirectory);
+    await resultManager._loadResults();
+    return resultManager;
+  }
 
-  Future<void> init() async {
+  List<ExtendedResult> results = [];
+  late final Directory _resultsDir;
+  late final List<File> _resultsFiles;
+
+  ResultManager._create(String applicationDirectory) {
+    _resultsDir = Directory('$applicationDirectory/$_resultsDirName');
+  }
+
+  Future<void> _loadResults() async {
     if (!await _resultsDir.exists()) {
       await _resultsDir.create(recursive: true);
     }

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -17,9 +17,9 @@ class ResultManager {
     return resultManager;
   }
 
-  List<ExtendedResult> results = [];
+  final List<ExtendedResult> results = [];
+  final List<File> _resultsFiles = [];
   late final Directory _resultsDir;
-  late final List<File> _resultsFiles;
 
   ResultManager._create(String applicationDirectory) {
     _resultsDir = Directory('$applicationDirectory/$_resultsDirName');
@@ -66,7 +66,8 @@ class ResultManager {
     results.add(value);
     final DateFormat formatter = DateFormat('yyyy-MM-dd_HHmmss');
     final String formatted = formatter.format(DateTime.now());
-    final jsonFile = File('${_resultsDir.path}/$formatted.json');
+    final filename = '${_resultsDir.path}/${formatted}_${value.meta.uuid}.json';
+    final jsonFile = File(filename);
     await jsonFile.writeAsString(jsonToStringIndented(value));
     print('Result saved to $jsonFile');
   }

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -32,6 +32,7 @@ class ProgressInfo {
   int totalStages = 0;
   int currentStage = 0;
   double cooldownDuration = 0;
+
   double get stageProgress => calculateStageProgress?.call() ?? 0.0;
 
   double Function()? calculateStageProgress;
@@ -232,7 +233,8 @@ class TaskRunner {
       return null;
     }
     return ExtendedResult(
-      meta: ResultMetaInfo(uuid: const Uuid().v4()),
+      meta:
+          ResultMetaInfo(creationDate: DateTime.now(), uuid: const Uuid().v4()),
       environmentInfo: DeviceInfo.instance.envInfo,
       results: exportResults,
       buildInfo: BuildInfoHelper.info,

--- a/flutter/lib/ui/history/history_tab.dart
+++ b/flutter/lib/ui/history/history_tab.dart
@@ -84,6 +84,7 @@ class HistoryTab implements TabInterface {
   );
 
   late Widget delete;
+
   Widget _makeDeleteButton(BuildContext context) => IconButton(
         icon: const Icon(Icons.delete),
         tooltip: l10n.historyListSelectionDelete,
@@ -135,13 +136,10 @@ class HistoryTab implements TabInterface {
   ) {
     final item = itemList[index];
     final results = item.results;
-    final firstRunInfo = results.first;
-    final startDatetime = firstRunInfo.performanceRun?.startDatetime ??
-        firstRunInfo.accuracyRun!.startDatetime;
     bool isSelected = selected![index];
 
     return helper.makeListItem(
-      title: helper.formatDate(startDatetime.toLocal()),
+      title: helper.formatDate(item.meta.creationDate.toLocal()),
       specialTitleColor: results.any(
           (runRes) => !(runRes.performanceRun?.loadgenInfo?.validity ?? false)),
       trailing: isSelectionMode

--- a/flutter/lib/ui/history/online_tab.dart
+++ b/flutter/lib/ui/history/online_tab.dart
@@ -106,14 +106,10 @@ class OnlineTab implements TabInterface {
   ) {
     final item = itemList[index];
     final results = item.results;
-    final firstRunInfo = results.first;
-    final startDatetime = firstRunInfo.performanceRun?.startDatetime ??
-        firstRunInfo.accuracyRun!.startDatetime;
-
     final utils = HistoryHelperUtils(l10n);
 
     return helper.makeListItem(
-      title: helper.formatDate(startDatetime.toLocal()),
+      title: helper.formatDate(item.meta.creationDate.toLocal()),
       specialTitleColor: results.any(
           (runRes) => !(runRes.performanceRun?.loadgenInfo?.validity ?? false)),
       subtitle: utils.makeModelDescription(item.environmentInfo),

--- a/flutter/lib/ui/history/result_details_screen.dart
+++ b/flutter/lib/ui/history/result_details_screen.dart
@@ -52,7 +52,7 @@ class _DetailsScreen extends State<DetailsScreen> {
     final res = widget.result;
 
     final firstResult = res.results.first;
-    final date = helper.formatDate(firstResult.performanceRun!.startDatetime);
+    final date = helper.formatDate(res.meta.creationDate);
     final backendName = firstResult.backendInfo.backendName;
 
     final averageThroughput =

--- a/flutter/lib/ui/history/utils.dart
+++ b/flutter/lib/ui/history/utils.dart
@@ -16,7 +16,7 @@ class HistoryHelperUtils {
   HistoryHelperUtils(this.l10n);
 
   String formatDate(DateTime value) {
-    var dateFormat = DateFormat('yyyy-MM-dd HH:mm');
+    var dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss');
     return dateFormat.format(value);
   }
 

--- a/flutter_common/lib/data/generation_helpers/sample_generator.dart
+++ b/flutter_common/lib/data/generation_helpers/sample_generator.dart
@@ -42,6 +42,7 @@ class SampleGenerator {
           validity: true,
         ),
       );
+
   BenchmarkExportResult get exportResult => BenchmarkExportResult(
         benchmarkId: 'id',
         benchmarkName: 'name',
@@ -73,6 +74,7 @@ class SampleGenerator {
         loadgenScenario:
             BenchmarkExportResult.parseLoadgenScenario('SingleStream'),
       );
+
   EnvironmentInfo get envInfo => EnvironmentInfo(
         platform: EnvPlatform.android,
         value: EnvInfoValue(
@@ -103,6 +105,7 @@ class SampleGenerator {
           ),
         ),
       );
+
   BuildInfo get buildInfo => BuildInfo(
         version: '1.0',
         buildNumber: '10qwe',
@@ -116,8 +119,10 @@ class SampleGenerator {
         ],
         officialReleaseFlag: false,
       );
+
   ExtendedResult get extendedResult => ExtendedResult(
         meta: ResultMetaInfo(
+          creationDate: DateTime.now(),
           uploadDate: DateTime.now(),
           uuid: const Uuid().v4(),
         ),

--- a/flutter_common/lib/data/meta_info.dart
+++ b/flutter_common/lib/data/meta_info.dart
@@ -10,10 +10,9 @@ class ResultMetaInfo {
 
   ResultMetaInfo({
     required this.uuid,
-    required DateTime creationDate,
+    required this.creationDate,
     DateTime? uploadDate,
-  })  : uploadDate = uploadDate?.toUtc(),
-        creationDate = creationDate.toUtc();
+  }) : uploadDate = uploadDate?.toUtc();
 
   factory ResultMetaInfo.fromJson(Map<String, dynamic> json) =>
       _$ResultMetaInfoFromJson(json);

--- a/flutter_common/lib/data/meta_info.dart
+++ b/flutter_common/lib/data/meta_info.dart
@@ -5,12 +5,15 @@ part 'meta_info.g.dart';
 @JsonSerializable(fieldRename: FieldRename.snake)
 class ResultMetaInfo {
   final String uuid;
+  final DateTime creationDate;
   final DateTime? uploadDate;
 
   ResultMetaInfo({
     required this.uuid,
+    required DateTime creationDate,
     DateTime? uploadDate,
-  }) : uploadDate = uploadDate?.toUtc();
+  })  : uploadDate = uploadDate?.toUtc(),
+        creationDate = creationDate.toUtc();
 
   factory ResultMetaInfo.fromJson(Map<String, dynamic> json) =>
       _$ResultMetaInfoFromJson(json);

--- a/flutter_common/test/data/result_sample.json
+++ b/flutter_common/test/data/result_sample.json
@@ -1,7 +1,8 @@
 {
   "meta": {
-    "uuid": "c96cf553-40de-4964-8530-7367b9341217",
-    "upload_date": "2022-11-20T08:31:40.637573Z"
+    "uuid": "19b74406-569b-4b00-b9e9-6a1df9d4a8e9",
+    "creation_date": "2022-12-09T08:07:13.066718Z",
+    "upload_date": "2022-12-09T08:07:13.066719Z"
   },
   "results": [
     {
@@ -41,7 +42,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-11-20T15:31:40.641167",
+        "start_datetime": "2022-12-09T15:07:13.070330",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -65,7 +66,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-11-20T15:31:40.641241",
+        "start_datetime": "2022-12-09T15:07:13.070407",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -117,7 +118,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-11-20T15:31:40.642490",
+        "start_datetime": "2022-12-09T15:07:13.071638",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -141,7 +142,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-11-20T15:31:40.642490",
+        "start_datetime": "2022-12-09T15:07:13.071638",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -190,7 +191,7 @@
   "build_info": {
     "version": "1.0",
     "build_number": "10qwe",
-    "build_date": "2022-11-20T15:31:40.640369",
+    "build_date": "2022-12-09T15:07:13.069544",
     "official_release_flag": false,
     "dev_test_flag": true,
     "backend_list": [

--- a/flutter_common/test/data/result_sample.json
+++ b/flutter_common/test/data/result_sample.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "uuid": "19b74406-569b-4b00-b9e9-6a1df9d4a8e9",
-    "creation_date": "2022-12-09T08:07:13.066718Z",
-    "upload_date": "2022-12-09T08:07:13.066719Z"
+    "uuid": "7b18d7bf-7461-4bbb-8aa4-fb06d8e282f5",
+    "creation_date": "2022-12-09T15:35:11.583110",
+    "upload_date": "2022-12-09T08:35:11.583111Z"
   },
   "results": [
     {
@@ -42,7 +42,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-12-09T15:07:13.070330",
+        "start_datetime": "2022-12-09T15:35:11.587791",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -66,7 +66,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-12-09T15:07:13.070407",
+        "start_datetime": "2022-12-09T15:35:11.587867",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -118,7 +118,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-12-09T15:07:13.071638",
+        "start_datetime": "2022-12-09T15:35:11.589247",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -142,7 +142,7 @@
         },
         "measured_duration": 123.456,
         "measured_samples": 8,
-        "start_datetime": "2022-12-09T15:07:13.071638",
+        "start_datetime": "2022-12-09T15:35:11.589248",
         "loadgen_info": {
           "validity": true,
           "duration": 10.6
@@ -191,7 +191,7 @@
   "build_info": {
     "version": "1.0",
     "build_number": "10qwe",
-    "build_date": "2022-12-09T15:07:13.069544",
+    "build_date": "2022-12-09T15:35:11.586901",
     "official_release_flag": false,
     "dev_test_flag": true,
     "backend_list": [

--- a/tools/extended-result.schema.json
+++ b/tools/extended-result.schema.json
@@ -249,6 +249,10 @@
                     "type": "string",
                     "format": "uuid"
                 },
+                "creation_date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
                 "upload_date": {
                     "format": "date-time",
                     "oneOf": [
@@ -262,6 +266,7 @@
                 }
             },
             "required": [
+                "creation_date",
                 "upload_date",
                 "uuid"
             ],


### PR DESCRIPTION
Instead of storing the results of multiple benchmark runs in one single `JSON` file, the app now stores the result of each run in a separated `JSON` file in the `results` directory.

This should resolve #617 where an existing file is overwritten when failed to parse.
This is also needed to simplify the process of uploading the benchmark result to a server, and also retrieving it from the server for listing and filtering purpose (as in https://github.com/mlcommons/mobile_app_open/issues/490).