### PR TITLE
fix: disable file_picker plugin on iOS

### DIFF
--- a/flutter/ios/Podfile
+++ b/flutter/ios/Podfile
@@ -29,6 +29,12 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 
 flutter_ios_podfile_setup
 
+# [file_picker] Currently custom data folder is not supported on iOS.
+# See https://github.com/mlcommons/mobile_app_open/pull/562#discussion_r992167655
+Pod::PICKER_MEDIA = false
+Pod::PICKER_AUDIO = false
+Pod::PICKER_DOCUMENT = false
+
 target 'Runner' do
   use_frameworks!
   use_modular_headers!

--- a/flutter/ios/Podfile.lock
+++ b/flutter/ios/Podfile.lock
@@ -1,6 +1,8 @@
 PODS:
   - device_info_plus (0.0.1):
     - Flutter
+  - file_picker (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
@@ -21,6 +23,7 @@ PODS:
 
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
+  - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -34,6 +37,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
+  file_picker:
+    :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
   integration_test:
@@ -55,7 +60,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  file_picker: d2c1b9bc9b423c1d9d969689630030a0e0562056
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
@@ -65,6 +71,6 @@ SPEC CHECKSUMS:
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
   wakelock: d0fc7c864128eac40eba1617cb5264d9c940b46f
 
-PODFILE CHECKSUM: 56e279c144a013448986db27bfcf32875ca896bf
+PODFILE CHECKSUM: b51a855f39d37a01eefba74b42596116ffbf1ff1
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Disable the file_picker plugin on iOS since custom folder is not supported on iOS for now and the plugin prevents the Xcode Cloud to finish the build.