### PR TITLE
feat: remove groundtruth_path in lite dataset

### DIFF
--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -19,7 +19,7 @@ task {
     lite {
       name: "Open images subset for classification"
       input_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/datasets/imagenet.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/assets/imagenet_val_tiny.txt"
+      groundtruth_path: ""
     }
     tiny {
       name: "Imagenet dataset for integration test"
@@ -55,7 +55,7 @@ task {
     lite {
       name: "Open images subset for detection"
       input_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/datasets/coco.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/assets/coco_val_tiny.pbtxt"
+      groundtruth_path: ""
     }
     tiny {
       name: "Coco dataset for integration test"
@@ -126,7 +126,7 @@ task {
     lite {
       name: "Squad V1.1 mini set"
       input_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/datasets/squad_eval_mini.tfrecord"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/assets/squad_groundtruth.tfrecord"
+      groundtruth_path: ""
     }
     tiny {
       name: "Squad V1.1 mini set"
@@ -158,7 +158,7 @@ task {
     lite {
       name: "Open images subset for classification"
       input_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/datasets/imagenet.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/assets/imagenet_val_tiny.txt"
+      groundtruth_path: ""
     }
     tiny {
       name: "Imagenet dataset for integration test"
@@ -194,7 +194,7 @@ task {
     lite {
       name: "SNUSR dataset for performance test"
       input_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/datasets/snusr_lr.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/datasets/snusr_hr.zip"
+      groundtruth_path: ""
     }
     tiny {
       name: "SNUSR dataset for integration test"


### PR DESCRIPTION
Part of https://github.com/mlcommons/mobile_app_open/issues/638

The lite dataset is used in performance mode, which does not need the ground truth for accuracy test.