### PR TITLE
test: rerun integration test when it failed

### DIFF
--- a/.github/cloudbuild/android-test.yaml
+++ b/.github/cloudbuild/android-test.yaml
@@ -27,7 +27,8 @@ steps:
           --type instrumentation \
           --app output/apks/$_APK_TEST_MAIN_NAME \
           --test output/apks/$_APK_TEST_HELPER_NAME \
-          --timeout 20m \
+          --timeout 30m \
+          --num-flaky-test-attempts 2 \
           --device $_DEVICE_SELECTOR
 
 timeout: 1500s # 25 minutes

--- a/.github/cloudbuild/android-test.yaml
+++ b/.github/cloudbuild/android-test.yaml
@@ -18,7 +18,7 @@ steps:
     name: gcr.io/cloud-builders/gcloud
     waitFor:
       - pull-apks
-    timeout: 1440s # 24 minutes
+    timeout: 1800s # 30 minutes
     entrypoint: bash
     args:
       - -xc
@@ -27,8 +27,8 @@ steps:
           --type instrumentation \
           --app output/apks/$_APK_TEST_MAIN_NAME \
           --test output/apks/$_APK_TEST_HELPER_NAME \
-          --timeout 30m \
+          --timeout 25m \
           --num-flaky-test-attempts 2 \
           --device $_DEVICE_SELECTOR
 
-timeout: 1500s # 25 minutes
+timeout: 2400s # 40 minutes

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -66,6 +66,7 @@ void checkTasks(ExtendedResult extendedResults) {
 }
 
 void checkAccuracy(BenchmarkExportResult benchmarkResult) {
+  var tag = '[benchmarkId: ${benchmarkResult.benchmarkId}';
   final expectedMap = benchmarkExpectedAccuracy[benchmarkResult.benchmarkId];
   expect(
     expectedMap,
@@ -75,11 +76,12 @@ void checkAccuracy(BenchmarkExportResult benchmarkResult) {
   expectedMap!;
 
   final accelerator = benchmarkResult.backendSettings.acceleratorCode;
+  tag += ' | accelerator: $accelerator';
   final backendName = benchmarkResult.backendInfo.backendName;
+  tag += ' | backendName: $backendName]';
   final expectedValue =
       expectedMap['$accelerator|$backendName'] ?? expectedMap[accelerator];
-  final tag =
-      '[benchmarkId: ${benchmarkResult.benchmarkId} | accelerator: $accelerator | backendName: $backendName]';
+  tag += ' | expectedValue: $expectedValue';
   expect(
     expectedValue,
     isNotNull,
@@ -147,6 +149,7 @@ void checkThroughput(
   final deviceModel = getDeviceModel(environmentInfo);
   tag += ' | deviceModel: $deviceModel';
   final expectedValue = backendExpectedMap[deviceModel];
+  tag += ' | expectedValue: $expectedValue';
   expect(
     expectedValue,
     isNotNull,

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -35,11 +35,13 @@ void main() {
 
   group('integration tests', () {
     final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-
     binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
 
-    testWidgets('run all and check', (WidgetTester tester) async {
-      await runBenchmark(tester);
+    testWidgets('run benchmarks', (WidgetTester tester) async {
+      await runBenchmarks(tester);
+    });
+
+    testWidgets('check results', (WidgetTester tester) async {
       final extendedResults = await obtainResult();
       printResults(extendedResults);
       checkTasks(extendedResults);

--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -15,6 +15,11 @@ class Interval {
   final double max;
 
   const Interval({required this.min, required this.max});
+
+  @override
+  toString() {
+    return '[$min, $max]';
+  }
 }
 
 Future<void> runBenchmark(WidgetTester tester) async {

--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -22,7 +22,7 @@ class Interval {
   }
 }
 
-Future<void> runBenchmark(WidgetTester tester) async {
+Future<void> runBenchmarks(WidgetTester tester) async {
   const splashPauseSeconds = 4;
   const runTimeLimitMinutes = 30;
   const downloadTimeLimitMinutes = 20;


### PR DESCRIPTION
- Added `num-flaky-test-attempts` flag to rerun the integration test if it failed.
- Increase integration test timeout.
- Print expected value to console when integration tests failed.