### PR TITLE
chore: pin buildifier to specific version

### DIFF
--- a/tools/formatter/Dockerfile
+++ b/tools/formatter/Dockerfile
@@ -21,36 +21,35 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 # Install dev packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    gcc make git curl wget zip unzip tar gzip
-RUN apt-get update && apt-get install -y build-essential
+    gcc make git curl wget zip unzip tar gzip build-essential
 
 ENV FORMATTER_HOME /opt/formatters/bin
 ENV PATH=${PATH}:${FORMATTER_HOME}
 RUN mkdir -p ${FORMATTER_HOME}
 
 # Install Java
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-11-jdk-headless
 
 # Add buildifier
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     golang-1.16-go
 ENV PATH=$PATH:/usr/lib/go-1.16/bin:~/go/bin
 RUN /usr/lib/go-1.16/bin/go get github.com/bazelbuild/buildtools/buildifier
 RUN cp ~/go/bin/buildifier ${FORMATTER_HOME}/
 
 # Add CLang formatter
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     clang-format-10
 RUN cp $(which clang-format-10) ${FORMATTER_HOME}/clang-format
 
 # Add dos2unix to format line endings
-RUN apt-get update && apt-get install -y dos2unix
+RUN apt-get update && apt-get install -y --no-install-recommends dos2unix
 
 # Install Node.js and NPM
 ENV NODE_ENV="production"
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN apt-get update && apt-get install -y nodejs && node -v
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs && node -v
 RUN npm install --location=global npm@8.13.2 && npm --version
 RUN npm install -g quicktype
 RUN npm install -g prettier
@@ -60,7 +59,7 @@ RUN npm install -g markdownlint-cli@0.26.0
 RUN npm install -g markdown-link-check@3.9.0
 
 # Add YAML linter
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
 	python3-pip
 RUN pip install yamllint==1.26.3
 
@@ -75,6 +74,6 @@ ENV PUB_CACHE=/home/.pub-cache
 ENV PATH=$PATH:/home/$UNAME/flutter/bin:/home/$UNAME/flutter/bin/cache/dart-sdk/bin:$PUB_CACHE/bin
 RUN flutter doctor -v
 RUN dart pub global activate protoc_plugin && chmod --recursive a=u $PUB_CACHE
-RUN apt-get install -y protobuf-compiler
+RUN apt-get install -y --no-install-recommends protobuf-compiler
 
 CMD /bin/bash

--- a/tools/formatter/Dockerfile
+++ b/tools/formatter/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     golang-1.16-go
 ENV PATH=$PATH:/usr/lib/go-1.16/bin:~/go/bin
-RUN /usr/lib/go-1.16/bin/go get github.com/bazelbuild/buildtools/buildifier
+RUN /usr/lib/go-1.16/bin/go get github.com/bazelbuild/buildtools/buildifier@6.0.1
 RUN cp ~/go/bin/buildifier ${FORMATTER_HOME}/
 
 # Add CLang formatter


### PR DESCRIPTION
The CI step [Format & lint / bazel](https://github.com/mlcommons/mobile_app_open/actions/runs/4475740219/jobs/7865521450) of [the last master merge](https://github.com/mlcommons/mobile_app_open/commit/1e03c3b69ced9e5e6e03a9cef16ce466793b2975) failed because the new `buildifier` version reordered the lines.

To fix it, we pin `buildifier` to a specific version to avoid possible issues with new versions.
Also, the flag `--no-install-recommends` was added as recommended by SonarScanner.