### PR TITLE
chore: update clang-format to v16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: Google
+
+...

--- a/tools/formatter/Dockerfile
+++ b/tools/formatter/Dockerfile
@@ -21,7 +21,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 # Install dev packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    gcc make git curl wget zip unzip tar gzip build-essential
+    gcc make git curl wget zip unzip tar gzip build-essential python3-pip
 
 ENV FORMATTER_HOME /opt/formatters/bin
 ENV PATH=${PATH}:${FORMATTER_HOME}
@@ -39,9 +39,7 @@ RUN /usr/lib/go-1.16/bin/go get github.com/bazelbuild/buildtools/buildifier@6.0.
 RUN cp ~/go/bin/buildifier ${FORMATTER_HOME}/
 
 # Add CLang formatter
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang-format-10
-RUN cp $(which clang-format-10) ${FORMATTER_HOME}/clang-format
+RUN pip install clang-format==16.0.0 && clang-format --version
 
 # Add dos2unix to format line endings
 RUN apt-get update && apt-get install -y --no-install-recommends dos2unix
@@ -59,8 +57,6 @@ RUN npm install -g markdownlint-cli@0.26.0
 RUN npm install -g markdown-link-check@3.9.0
 
 # Add YAML linter
-RUN apt-get update && apt-get install -y --no-install-recommends \
-	python3-pip
 RUN pip install yamllint==1.26.3
 
 

--- a/tools/formatter/format.mk
+++ b/tools/formatter/format.mk
@@ -9,7 +9,7 @@ format/bazel:
 
 .PHONY: format/clang
 format/clang:
-	git ls-files -z | grep --null-data "\.h$$\|\.hpp$$\|\.cc$$\|\.cpp$$\|\.proto$$" | xargs --null --no-run-if-empty clang-format -i -style=google
+	git ls-files -z | grep --null-data "\.h$$\|\.hpp$$\|\.cc$$\|\.cpp$$\|\.proto$$" | xargs --null --no-run-if-empty clang-format -i --style=file
 
 .PHONY: format/dart/pub-get
 format/dart/pub-get:
@@ -52,7 +52,7 @@ lint/bazel:
 
 .PHONY: lint/clang
 lint/clang:
-	git ls-files -z | grep --null-data "\.h$$\|\.hpp$$\|\.cc$$\|\.cpp$$\|\.proto$$" | xargs --null --no-run-if-empty clang-format -i -style=google --Werror --dry-run
+	git ls-files -z | grep --null-data "\.h$$\|\.hpp$$\|\.cc$$\|\.cpp$$\|\.proto$$" | xargs --null --no-run-if-empty clang-format -i --style=file --Werror --dry-run
 
 .PHONY: lint/dart
 lint/dart: format/dart/pub-get


### PR DESCRIPTION
1. Add `.clang-format` file, so IDEs can detect the correct formatting style used in the project.
1. Update `clang-format` from `v10` ([released on Mar 24, 2020](https://github.com/llvm/llvm-project/releases/tag/llvmorg-10.0.0)) to `v16` ([latest release](https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.0)). Running `clang-format` `v10` or `v16` does not change any files, so the 2 versions are compatible.

