### PR TITLE
chore: vendor backend can choose to load fallback backend or not

### DIFF
--- a/flutter/cpp/c/backend_c.h
+++ b/flutter/cpp/c/backend_c.h
@@ -23,7 +23,11 @@ limitations under the License.
 extern "C" {
 #endif  // __cplusplus
 
-// Should return true if current hardware is supported.
+// Should return true and set not_allowed_message to a nullptr if the current hardware is supported.
+// Case 1: Return true and set not_allowed_message to a nullptr. The app will run with matched backend.
+// Case 2: Return true and set not_allowed_message to a string. The app will show an error screen with the text from not_allowed_message.
+// Case 3: Return false and set not_allowed_message to a nullptr. The app will load the next backend in the backend list.
+// Case 4: Return false and set not_allowed_message to a string. The app will load the next backend in the backend list.
 bool mlperf_backend_matches_hardware(const char** not_allowed_message,
                                      const char** settings,
                                      const mlperf_device_info_t* device_info);

--- a/flutter/cpp/c/backend_c.h
+++ b/flutter/cpp/c/backend_c.h
@@ -23,11 +23,16 @@ limitations under the License.
 extern "C" {
 #endif  // __cplusplus
 
-// Should return true and set not_allowed_message to a nullptr if the current hardware is supported.
-// Case 1: Return true and set not_allowed_message to a nullptr. The app will run with matched backend.
-// Case 2: Return true and set not_allowed_message to a string. The app will show an error screen with the text from not_allowed_message.
-// Case 3: Return false and set not_allowed_message to a nullptr. The app will load the next backend in the backend list.
-// Case 4: Return false and set not_allowed_message to a string. The app will load the next backend in the backend list.
+// Should return true and set not_allowed_message to a nullptr if
+// the current hardware is supported.
+// Case 1: Return true and set not_allowed_message to a nullptr.
+//         The app will run with this matched backend.
+// Case 2: Return true and set not_allowed_message to a string.
+//         The app will show an error screen with text from not_allowed_message.
+// Case 3: Return false and set not_allowed_message to a nullptr.
+//         The app will load the next backend in the backend list.
+// Case 4: Return false and set not_allowed_message to a string.
+//         The app will load the next backend in the backend list.
 bool mlperf_backend_matches_hardware(const char** not_allowed_message,
                                      const char** settings,
                                      const mlperf_device_info_t* device_info);

--- a/flutter/lib/ui/root/unsupported_device_screen.dart
+++ b/flutter/lib/ui/root/unsupported_device_screen.dart
@@ -13,47 +13,58 @@ class UnsupportedDeviceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final stringResources = AppLocalizations.of(context);
+    final l10n = AppLocalizations.of(context);
 
     final iconEdgeSize = MediaQuery.of(context).size.width * 0.66;
-
     return Scaffold(
       body: getSinglePageView(
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Expanded(
-                flex: 3,
-                child: Align(
-                    alignment: Alignment.bottomCenter,
-                    child: SizedBox(
-                        height: iconEdgeSize,
-                        width: iconEdgeSize,
-                        child: AppIcons.error))),
-            Expanded(
-                child: Padding(
-                    padding: const EdgeInsets.fromLTRB(35, 0, 35, 0),
-                    child: Align(
-                        alignment: Alignment.topCenter,
-                        child: Column(
-                          children: [
-                            Text(stringResources.unsupportedMainMessage,
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                    fontSize: 15, color: AppColors.darkText)),
-                            Text(
-                                '${stringResources.unsupportedBackendError}: $backendError',
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                    fontSize: 15, color: AppColors.darkText)),
-                            Text(stringResources.unsupportedTryAnotherDevice,
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                    fontSize: 15, color: AppColors.darkText)),
-                          ],
-                        )))),
-          ],
+        Padding(
+          padding: const EdgeInsets.only(top: 50),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Align(
+                alignment: Alignment.center,
+                child: SizedBox(
+                  height: iconEdgeSize,
+                  width: iconEdgeSize,
+                  child: AppIcons.error,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      l10n.unsupportedMainMessage,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.unsupportedTryAnotherDevice,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    const Divider(height: 32),
+                    Text(
+                      l10n.unsupportedBackendError,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      backendError,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/flutter/lib/ui/root/unsupported_device_screen.dart
+++ b/flutter/lib/ui/root/unsupported_device_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/ui/icons.dart' show AppIcons;
 import 'package:mlperfbench/ui/page_constraints.dart';

--- a/mobile_back_tflite/tflite_backend.mk
+++ b/mobile_back_tflite/tflite_backend.mk
@@ -14,6 +14,7 @@
 ##########################################################################
 
 ifeq (${WITH_TFLITE},1)
+  $(info WITH_TFLITE=1)
   backend_tflite_windows_files=${BAZEL_LINKS_PREFIX}bin/mobile_back_tflite/cpp/backend_tflite/libtflitebackend.dll
   backend_tflite_windows_target=//mobile_back_tflite/cpp/backend_tflite:libtflitebackend.dll
   backend_tflite_android_files=${BAZEL_LINKS_PREFIX}bin/mobile_back_tflite/cpp/backend_tflite/libtflitebackend.so
@@ -22,8 +23,6 @@ ifeq (${WITH_TFLITE},1)
   backend_tflite_ios_zip=${BAZEL_LINKS_PREFIX}bin/mobile_back_tflite/cpp/backend_tflite/ios/libtflitebackend.xcframework.zip
   backend_tflite_filename=libtflitebackend
 else
-  # tflite is enabled by default, so print log message only if someone disabled it
-  $(info WITH_TFLITE=0)
   # xcode will give you an error if a backend is specified in xcode config but the file is missing
   backend_tflite_ios_target=//mobile_back_tflite/cpp/backend_dummy/ios:libtflitebackend
   backend_tflite_ios_zip=${BAZEL_LINKS_PREFIX}bin/mobile_back_tflite/cpp/backend_dummy/ios/libtflitebackend.xcframework.zip


### PR DESCRIPTION
Related to #662

The app already supported the case that vendor backend can decide whether the app should load the TFLite fallback backend or not.

For example, this code
```C++
bool mlperf_backend_matches_hardware(const char **not_allowed_message,
                                     const char **settings,
                                     const mlperf_device_info_t *device_info) {
  (void)device_info;
  *not_allowed_message = "We have a matched backend. But it's not supported yet. And we don't want to use the TFLite fallback backend either.";
  *settings = coreml_settings.c_str();
  return true;
}
```

will show this screen:

<img src="https://user-images.githubusercontent.com/85728587/235578040-2d6d5404-2d11-4aec-ad34-4353c816a9b9.jpeg" width="300">

I added a comment to explain it.
https://github.com/mlcommons/mobile_app_open/blob/0e6cdd79531fcaeb0844f2cc2001b05165ea11d1/flutter/cpp/c/backend_c.h#L26-L33

and also made some UI updates to the error screen.
