### PR TITLE
Use png for ade20k

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,8 +53,9 @@ http_archive(
     name = "org_tensorflow",
     patch_args = ["-p1"],
     patches = [
-        # Add patch for adding png in tflite evaluation code
+        # Add patches for adding png in tflite evaluation code
         "//:flutter/third_party/enable-png-in-tensorflow-lite-tools-evaluation.patch",
+        "//:flutter/third_party/png-with-number-of-channels-detected.patch",
         # Fix tensorflow not being able to read image files on Windows
         "//:flutter/third_party/tensorflow-fix-file-opening-mode-for-Windows.patch",
         "//:flutter/third_party/tf-eigen.patch",

--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -96,7 +96,7 @@ task {
     tiny {
       name: "Open images subset for segmentation"
       input_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/datasets/ade20k_tiny.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/assets/ade20k-tiny-saved-output.zip"
+      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/assets/ade20k_tiny_annotations.zip"
     }
   }
   model {

--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -95,8 +95,8 @@ task {
     }
     tiny {
       name: "Open images subset for segmentation"
-      input_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/datasets/ade20k_tiny.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/assets/ade20k_tiny_annotations.zip"
+      input_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_1/datasets/ade20k_tiny.zip"
+      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_1/datasets/ade20k_tiny_annotations.zip"
     }
   }
   model {

--- a/flutter/cpp/datasets/README.md
+++ b/flutter/cpp/datasets/README.md
@@ -81,6 +81,7 @@ you need to replace `squad_eval_mini.tfrecord` by `squad_eval.tfrecord` in the
 2. prepare 512x512 images and and ground truth file with something like the following
 
    using .jpg inputs:
+
     ```python
     import os
     import tensorflow as tf
@@ -113,6 +114,7 @@ you need to replace `squad_eval_mini.tfrecord` by `squad_eval.tfrecord` in the
     ```
 
    using .png inputs:
+
     ```python
     home = os.getenv("HOME")
     ADE20K_PATH = home + '/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'

--- a/flutter/cpp/datasets/README.md
+++ b/flutter/cpp/datasets/README.md
@@ -80,6 +80,7 @@ you need to replace `squad_eval_mini.tfrecord` by `squad_eval.tfrecord` in the
 1. follow [DeepLab's instruction](https://github.com/tensorflow/models/blob/master/research/deeplab/g3doc/ade20k.md) to download the ADE20K dataset
 2. prepare 512x512 images and and ground truth file with something like the following
 
+   using .jpg inputs:
     ```python
     import os
     import tensorflow as tf
@@ -94,19 +95,46 @@ you need to replace `squad_eval_mini.tfrecord` by `squad_eval.tfrecord` in the
     for i in range(1, 2001):
         image_jpeg = ADE20K_PATH+f'images/validation/ADE_val_0000{i:04}.jpg'
         label_png = ADE20K_PATH+f'annotations/validation/ADE_val_0000{i:04}.png'
+
+        image_jpeg_data = tf.io.read_file(image_jpeg)
+        image_tensor = tf.io.decode_jpeg(image_jpeg_data)
+        label_png_data = tf.io.read_file(label_png)
+        label_tensor = tf.io.decode_png(label_png_data)
+        o_image, p_image, p_label = deeplab.input_preprocess.preprocess_image_and_label(image_tensor, label_tensor, 512, 512, 512, 512, is_training=False)
+    
+        target_image_jpeg = f'/tmp/ade20k_512/images/validation/ADE_val_0000{i:04}.jpg'
+        target_label_png = f'/tmp/ade20k_512/annotations/ADE_val_0000{i:04}.png'
+    
+        resized_image = Image.fromarray(tf.reshape(tf.cast(p_image, tf.uint8), [512, 512, 3]).numpy())
+        resized_image.save(target_image_jpeg, quality=100, subsampling=0))
+
+        resized_label = Image.fromarray(tf.reshape(tf.cast(p_label, tf.uint8), [512, 512]).numpy())
+        resized_label.save(target_label_png)
+    ```
+
+   using .png inputs:
+    ```python
+    home = os.getenv("HOME")
+    ADE20K_PATH = home + '/tf-models/research/deeplab/datasets/ADE20K/ADEChallengeData2016/'
+
+    for i in range(1, 2001):
+        image_jpeg = ADE20K_PATH+f'images/validation/ADE_val_0000{i:04}.jpg'
+        label_png = ADE20K_PATH+f'annotations/validation/ADE_val_0000{i:04}.png'
         # print(image_jpeg)
         image_jpeg_data = tf.io.read_file(image_jpeg)
         image_tensor = tf.io.decode_jpeg(image_jpeg_data)
         label_png_data = tf.io.read_file(label_png)
-        label_tensor = tf.io.decode_jpeg(label_png_data)
+        label_tensor = tf.io.decode_png(label_png_data)
         o_image, p_image, p_label = deeplab.input_preprocess.preprocess_image_and_label(image_tensor, label_tensor, 512, 512, 512, 512, is_training=False)
-    
-        target_image_jpeg = f'/tmp/ade20k_512/images/validation/ADE_val_0000{i:04}.jpg'
-        target_label_raw = f'/tmp/ade20k_512/annotations/raw/ADE_val_0000{i:04}.raw'
-    
+
+        target_image_png = f'/tmp/ade20k_512/images/validation/ADE_val_0000{i:04}.png'
+        target_label_png = f'/tmp/ade20k_512/annotations/ADE_val_0000{i:04}.png'
+
         resized_image = Image.fromarray(tf.reshape(tf.cast(p_image, tf.uint8), [512, 512, 3]).numpy())
-        resized_image.save(target_image_jpeg)
-        tf.reshape(tf.cast(p_label, tf.uint8), [512, 512]).numpy().tofile(target_label_raw)
+        resized_image.save(target_image_png)
+
+        resized_label = Image.fromarray(tf.reshape(tf.cast(p_label, tf.uint8), [512, 512]).numpy())
+        resized_label.save(target_label_png)
     ```
 
 3. Build command line tool to test performance and accuracy on x86 host

--- a/flutter/cpp/datasets/ade20k.cc
+++ b/flutter/cpp/datasets/ade20k.cc
@@ -43,7 +43,7 @@ ADE20K::ADE20K(Backend *backend, const std::string &image_dir,
   }
 
   // Finds all images under image_dir.
-  std::unordered_set<std::string> exts{".rgb8", ".jpg", ".jpeg"};
+  std::unordered_set<std::string> exts{".rgb8", ".jpg", ".jpeg", ".png"};
   image_list_ = GetSortedFileNames(image_dir, exts);
   if (image_list_.empty()) {
     LOG(FATAL) << "Failed to list all the image files in provided path";

--- a/flutter/cpp/datasets/ade20k.cc
+++ b/flutter/cpp/datasets/ade20k.cc
@@ -53,7 +53,7 @@ ADE20K::ADE20K(Backend *backend, const std::string &image_dir,
       std::vector<std::vector<uint8_t, BackendAllocator<uint8_t>> *>>(
       image_list_.size());
   // Finds all ground truth files under ground_truth_dir.
-  std::unordered_set<std::string> gt_exts{".raw"};
+  std::unordered_set<std::string> gt_exts{".png"};
   ground_truth_list_ = GetSortedFileNames(ground_truth_dir, gt_exts);
   if (ground_truth_list_.empty()) {
     LOG(WARNING)
@@ -69,6 +69,15 @@ ADE20K::ADE20K(Backend *backend, const std::string &image_dir,
       new tflite::evaluation::ImagePreprocessingStage(builder.build()));
   if (preprocessing_stage_->Init() != kTfLiteOk) {
     LOG(FATAL) << "Failed to init preprocessing stage";
+  }
+
+  // Always use uint8_t for ground truth image
+  tflite::evaluation::ImagePreprocessingConfigBuilder gt_builder("ground_truth",
+                                                                 kTfLiteUInt8);
+  gt_preprocessing_stage_.reset(
+      new tflite::evaluation::ImagePreprocessingStage(gt_builder.build()));
+  if (gt_preprocessing_stage_->Init() != kTfLiteOk) {
+    LOG(FATAL) << "Failed to init gt preprocessing stage";
   }
 
   counted_ = std::vector<bool>(image_list_.size(), false);
@@ -127,10 +136,13 @@ std::vector<uint8_t> ADE20K::ProcessOutput(const int sample_idx,
 
   if (!counted_[sample_idx]) {
     std::string filename = ground_truth_list_.at(sample_idx);
-    std::ifstream stream(filename, std::ios::in | std::ios::binary);
-    std::vector<uint8_t> ground_truth_vector(
-        (std::istreambuf_iterator<char>(stream)),
-        std::istreambuf_iterator<char>());
+    gt_preprocessing_stage_->SetImagePath(&filename);
+    if (gt_preprocessing_stage_->Run() != kTfLiteOk) {
+      LOG(FATAL) << "Failed to load ground truth image " << filename;
+    }
+
+    auto ground_truth_vector =
+        (uint8_t *)gt_preprocessing_stage_->GetPreprocessedImageData();
 
     float *outputFloat = reinterpret_cast<float *>(outputs[0]);
     int32_t *outputInt = reinterpret_cast<int32_t *>(outputs[0]);

--- a/flutter/cpp/datasets/ade20k.h
+++ b/flutter/cpp/datasets/ade20k.h
@@ -84,6 +84,9 @@ class ADE20K : public Dataset {
   // preprocessing_stage_ conducts preprocessing of images.
   std::unique_ptr<tflite::evaluation::ImagePreprocessingStage>
       preprocessing_stage_;
+  // gt_preprocessing_stage_ for loading groundtruth images.
+  std::unique_ptr<tflite::evaluation::ImagePreprocessingStage>
+      gt_preprocessing_stage_;
 
   // Number of classes in the output of the model.
   int num_classes_;

--- a/flutter/integration_test/expected_accuracy.dart
+++ b/flutter/integration_test/expected_accuracy.dart
@@ -27,11 +27,11 @@ const Map<String, Interval> _objectDetection = {
 };
 
 const Map<String, Interval> _imageSegmentation = {
-  'cpu': Interval(min: 0.83, max: 0.84),
-  'npu': Interval(min: 0.48, max: 0.49),
-  'tpu': Interval(min: 0.48, max: 0.49),
-  'ane|TFLite': Interval(min: 0.80, max: 0.84),
-  'ane|Core ML': Interval(min: 0.82, max: 0.84),
+  'cpu': Interval(min: 0.38, max: 0.40),
+  'npu': Interval(min: 0.33, max: 0.34),
+  'tpu': Interval(min: 0.33, max: 0.34),
+  'ane|TFLite': Interval(min: 0.38, max: 0.40),
+  'ane|Core ML': Interval(min: 0.38, max: 0.40),
 };
 
 const Map<String, Interval> _naturalLanguageProcessing = {

--- a/flutter/third_party/enable-png-in-tensorflow-lite-tools-evaluation.patch
+++ b/flutter/third_party/enable-png-in-tensorflow-lite-tools-evaluation.patch
@@ -44,7 +44,7 @@ index a1418c3bcb6..a9750141b3d 100644
 +// Loads the png image.
 +inline void LoadImagePng(std::string* filename, ImageData* image_data) {
 +  // Reads image.
-+  std::ifstream t(*filename);
++  std::ifstream t(*filename, std::ios::binary);
 +  std::string image_str((std::istreambuf_iterator<char>(t)),
 +                        std::istreambuf_iterator<char>());
 +

--- a/flutter/third_party/png-with-number-of-channels-detected.patch
+++ b/flutter/third_party/png-with-number-of-channels-detected.patch
@@ -1,0 +1,41 @@
+From 63e353ca8a29515fdd12b0d1ce69800f144bb22b Mon Sep 17 00:00:00 2001
+From: Koan-Sin Tan <koansin.tan@gmail.com>
+Date: Fri, 21 Apr 2023 06:25:00 +0800
+Subject: [PATCH] detect number of channels instead of forcing 3 (RGB)
+
+---
+ .../evaluation/stages/image_preprocessing_stage.cc  | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
+index a9750141b3d..47b5ed09a20 100644
+--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
++++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
+@@ -116,16 +116,19 @@ inline void LoadImagePng(std::string* filename, ImageData* image_data) {
+                         std::istreambuf_iterator<char>());
+
+   tensorflow::png::DecodeContext context;
+-  CHECK(CommonInitDecode(image_str, 3 /*RGB*/, 8 /*uint8*/, &context));
+-  char* image_buffer = new char[3 * context.width * context.height];
++  // 0: channels is detected from the input
++  CHECK(CommonInitDecode(image_str, 0, 8 /*uint8*/, &context));
++  char* image_buffer =
++      new char[context.channels * context.width * context.height];
+   CHECK(CommonFinishDecode(absl::bit_cast<png_byte*>(image_buffer),
+-                           3 * context.width /*stride*/, &context));
++                           context.channels * context.width /*stride*/,
++                           &context));
+
+   image_data->width = context.width;
+   image_data->height = context.height;
+   std::vector<float>* float_image = new std::vector<float>();
+-  float_image->reserve(3 * context.width * context.height);
+-  for (int i = 0; i < 3 * context.width * context.height; ++i) {
++  float_image->reserve(context.channels * context.width * context.height);
++  for (int i = 0; i < context.channels * context.width * context.height; ++i) {
+     float_image->push_back(static_cast<float>(image_buffer[i]));
+   }
+   image_data->data.reset(float_image);
+---
+2.34.1
+


### PR DESCRIPTION
Since we already have .png support, we can enable .png for ADE20k. Benefits of using .png

- input data: with .png we can use lossless resized data instead of lossy .jpeg
- label: with .png we can have small data size, previously, we used raw 512x512x1 data. 

See #695 for related discussion.