### PR TITLE
Use PNG groundtruth for ADE20K tiny dataset 

### DIFF
--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -95,8 +95,8 @@ task {
     }
     tiny {
       name: "Open images subset for segmentation"
-      input_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/datasets/ade20k_tiny.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/assets/ade20k_tiny_annotations.zip"
+      input_path: "https://github.com/mlcommons/mobile_models/raw/a45c78473981052c711ec63b1a75a70933c5ae11/v3_1/datasets/ade20k_tiny.zip"
+      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/a45c78473981052c711ec63b1a75a70933c5ae11/v3_1/datasets/ade20k_tiny_annotations.zip"
     }
   }
   model {

--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -95,8 +95,8 @@ task {
     }
     tiny {
       name: "Open images subset for segmentation"
-      input_path: "https://github.com/mlcommons/mobile_models/raw/a45c78473981052c711ec63b1a75a70933c5ae11/v3_1/datasets/ade20k_tiny.zip"
-      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/a45c78473981052c711ec63b1a75a70933c5ae11/v3_1/datasets/ade20k_tiny_annotations.zip"
+      input_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_1/datasets/ade20k_tiny.zip"
+      groundtruth_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_1/datasets/ade20k_tiny_annotations.zip"
     }
   }
   model {

--- a/flutter/integration_test/expected_accuracy.dart
+++ b/flutter/integration_test/expected_accuracy.dart
@@ -27,11 +27,11 @@ const Map<String, Interval> _objectDetection = {
 };
 
 const Map<String, Interval> _imageSegmentation = {
-  'cpu': Interval(min: 0.83, max: 0.84),
-  'npu': Interval(min: 0.48, max: 0.49),
-  'tpu': Interval(min: 0.48, max: 0.49),
-  'ane|TFLite': Interval(min: 0.80, max: 0.84),
-  'ane|Core ML': Interval(min: 0.82, max: 0.84),
+  'cpu': Interval(min: 0.38, max: 0.40),
+  'npu': Interval(min: 0.33, max: 0.34),
+  'tpu': Interval(min: 0.33, max: 0.34),
+  'ane|TFLite': Interval(min: 0.38, max: 0.40),
+  'ane|Core ML': Interval(min: 0.38, max: 0.40),
 };
 
 const Map<String, Interval> _naturalLanguageProcessing = {


### PR DESCRIPTION
I updated the CI tests. It runs ok on Android and iOS now, but failed on Windows. Unfortunately, I don't have a Windows device to debug it. But here is the log [log-25fc7b21-5ce5-4c86-8ea3-c311eb52feea.txt](https://github.com/mlcommons/mobile_app_open/files/11441104/log-25fc7b21-5ce5-4c86-8ea3-c311eb52feea.txt). It failed when trying to run the `image_segmentation_v2` task, so I assume it has to do with the changes in https://github.com/mlcommons/mobile_app_open/pull/707.
