### PR TITLE
chore: use release link for QTI model_path

### DIFF
--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sd7g1.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sd7g1.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
 }
 
@@ -49,7 +49,7 @@ benchmark_setting {
     id: "scenario"
     value: "Offline"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched_sd7g1.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_sd7g1.dlc"
   model_checksum: "dc8c71f98e67af3667c7dcdf531ce661"
 }
 
@@ -66,7 +66,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -95,7 +95,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -116,7 +116,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -137,7 +137,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sd7pg2.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sd7pg2.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
   single_stream_expected_latency_ns: 600000
 }
@@ -54,7 +54,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched_sd8pg1.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_sd8pg1.dlc"
   model_checksum: "59535a0aae60d21ddf35bbcac79a4c71"
 }
 
@@ -71,7 +71,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -100,7 +100,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -121,7 +121,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -142,7 +142,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sd8cxg3.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sd8cxg3.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
   single_stream_expected_latency_ns: 600000
 }
@@ -54,7 +54,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched_sd8cxg3.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_sd8cxg3.dlc"
   model_checksum: "4a73e95f0b48384daf94fc53d4a2aec3"
 }
 
@@ -71,7 +71,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -96,7 +96,7 @@ benchmark_setting {
     id: "use_ion_buffer"
     value: "false"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -117,7 +117,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -130,7 +130,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sd8g1.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sd8g1.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
   single_stream_expected_latency_ns: 800000
 }
@@ -54,7 +54,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched.dlc"
   model_checksum: "b9034e23621f96c86160101928e8e8ea"
 }
 
@@ -71,7 +71,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -100,7 +100,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -121,7 +121,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -142,7 +142,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sd8g2.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sd8g2.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
   single_stream_expected_latency_ns: 500000
 }
@@ -54,7 +54,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched_sd8g2.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_sd8g2.dlc"
   model_checksum: "78a54fc8913d4fa654dcd41a26850c1e"
 }
 
@@ -71,7 +71,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -100,7 +100,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "sustained_high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -121,7 +121,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -142,7 +142,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sd8pg1.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sd8pg1.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
   single_stream_expected_latency_ns: 600000
 }
@@ -54,7 +54,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched_sd8pg1.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_sd8pg1.dlc"
   model_checksum: "59535a0aae60d21ddf35bbcac79a4c71"
 }
 
@@ -71,7 +71,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -100,7 +100,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "sustained_high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -121,7 +121,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -142,7 +142,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sdm778.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sdm778.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
 }
 
@@ -49,7 +49,7 @@ benchmark_setting {
     id: "scenario"
     value: "Offline"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched.dlc"
   model_checksum: "b9034e23621f96c86160101928e8e8ea"
 }
 
@@ -66,7 +66,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -95,7 +95,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -116,7 +116,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -137,7 +137,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 

--- a/mobile_back_qti/cpp/backend_qti/qti_settings_sdm888.h
+++ b/mobile_back_qti/cpp/backend_qti/qti_settings_sdm888.h
@@ -35,7 +35,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
   model_checksum: "2e7c4d33b480b5566bdf05e1204b6152"
 }
 
@@ -49,7 +49,7 @@ benchmark_setting {
     id: "scenario"
     value: "Offline"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilenet_edgetpu_224_1.0_htp_batched.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched.dlc"
   model_checksum: "b9034e23621f96c86160101928e8e8ea"
 }
 
@@ -66,7 +66,7 @@ benchmark_setting {
     id: "bg_load"
     value: "true"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/ssd_mobiledet_qat_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/ssd_mobiledet_qat_htp.dlc"
   model_checksum: "65937d5b58414d86fc42872945e2f5cf"
 }
 
@@ -95,7 +95,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "high_performance"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobilebert_quantized_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobilebert_quantized_htp.dlc"
   model_checksum: "6dc1f1a47a764381b00c8423b07caac1"
 }
 
@@ -116,7 +116,7 @@ benchmark_setting {
     id: "output_buffer_type"
     value: "int_32"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/mobile_mosaic_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/mobile_mosaic_htp.dlc"
   model_checksum: "e921828320d251a5f7160952bbd750ec"
 }
 
@@ -137,7 +137,7 @@ benchmark_setting {
     id: "perf_profile"
     value: "burst"
   }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/SNPE/snusr_htp.dlc"
+  model_path: "https://github.com/mlcommons/mobile_models/releases/download/v3.0-snpe/snusr_htp.dlc"
   model_checksum: "3dc4b1e7ae23620704d76b56f88527d0"
 })SETTINGS";
 


### PR DESCRIPTION
Use release link for QTI model_path

(cherry picked from commit 19f38f4cd46adb6eea3b1d61cd188c104d97ff74)