### PR TITLE
ci: pin protoc_plugin to v20.0.1 instead of using latest version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Create ephemeral files
         run: |
           flutter config --no-analytics &&
-          dart pub global activate protoc_plugin &&
+          dart pub global activate protoc_plugin ^20.0.1 &&
           export PATH="$PATH:$HOME/.pub-cache/bin" &&
           make flutter/prepare
       - name: Run Flutter tests

--- a/docs/environment-setup/env-setup-android.md
+++ b/docs/environment-setup/env-setup-android.md
@@ -91,7 +91,7 @@ Flutter requires native libs so you must complete [Setting up Bazel on Ubuntu](#
 
     You will need to restart your WSL instance to apply changes.  
     Run `wsl --shutdown` in Windows, and then reopen WSL.
-* Enable protobuf plugin: `dart pub global activate protoc_plugin`
+* Enable protobuf plugin: `dart pub global activate protoc_plugin ^20.0.1`
 
 * Install dependencies via sdkmanager, accept licenses for dependencies:
 

--- a/docs/environment-setup/env-setup-ios.md
+++ b/docs/environment-setup/env-setup-ios.md
@@ -30,7 +30,7 @@ Otherwise, you can get errors about missing pods
 
   * Add flutter binary folders to path: `export PATH="$PATH:$HOME/tools/flutter/bin:$HOME/.pub-cache/bin"`  
     If you use zsh: `echo export PATH="\$PATH:\$HOME/tools/flutter/bin:\$HOME/.pub-cache/bin" >>~/.zshrc`
-  * Enable protobuf plugin: `dart pub global activate protoc_plugin`
+  * Enable protobuf plugin: `dart pub global activate protoc_plugin ^20.0.1`
 * Go to `ios` directory and install pods: `pod install`
 
 ## Tested environment

--- a/docs/environment-setup/env-setup-windows.md
+++ b/docs/environment-setup/env-setup-windows.md
@@ -25,7 +25,7 @@ However, using Chocolatey greatly simplifies installation.
   * `choco install -y msys2`
   * `choco install -y flutter`
   * `choco install -y protoc`
-  * `dart pub global activate protoc_plugin`
+  * `dart pub global activate protoc_plugin ^20.0.1`
 * Configure python
   * You must have command `python3` in your PATH.  
   Python installed via Chocolatey provides only `python.exe` file, so you will need to create `python3` yourself.  
@@ -40,7 +40,7 @@ However, using Chocolatey greatly simplifies installation.
 * Set python path env, paths must use forward slashes
 * Install python dependencies: `python3 -m pip install --user numpy absl-py`
 * Add MSYS2 bin folder to PATH: `C:/tools/msys64/usr/bin`
-* Enable protobuf plugin: `dart pub global activate protoc_plugin`
+* Enable protobuf plugin: `dart pub global activate protoc_plugin ^20.0.1`
 * Add dart pub cache bin folder to PATH: `%LOCALAPPDATA%/Pub/Cache/bin`
 * Turn on the developer mode in Windows settings.
   * This option should be located in `Update & Security` → `For developers`.

--- a/flutter/android/docker/Dockerfile
+++ b/flutter/android/docker/Dockerfile
@@ -53,7 +53,7 @@ ENV PATH=$PATH:$HOME/flutter/bin:$PUB_CACHE/bin
 RUN curl --proto '=https' -L https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.6-stable.tar.xz | tar Jxf - && chmod --recursive a=u $HOME/flutter
 RUN git config --global --add safe.directory $HOME/flutter
 RUN flutter config --no-analytics && dart --disable-analytics
-RUN dart pub global activate protoc_plugin && chmod --recursive a=u $PUB_CACHE
+RUN dart pub global activate protoc_plugin ^20.0.1 && chmod --recursive a=u $PUB_CACHE
 
 RUN mkdir -p $HOME/.cache/ && chmod 777 $HOME/.cache/
 RUN mkdir -p $HOME/.cache/.gradle && chmod 777 $HOME/.cache/.gradle

--- a/flutter/ios/ci_scripts/ci_post_clone.sh
+++ b/flutter/ios/ci_scripts/ci_post_clone.sh
@@ -100,7 +100,7 @@ test ! -d "$MC_FLUTTER_HOME" && git clone --branch 3.7.6 --depth 1 https://githu
 export PATH="$PATH:$MC_FLUTTER_HOME/bin:$PUB_CACHE/bin"
 echo "$MC_LOG_PREFIX flutter version:" && flutter --version
 flutter config --no-analytics && dart --disable-analytics
-dart pub global activate protoc_plugin
+dart pub global activate protoc_plugin ^20.0.1
 cd "$MC_REPO_HOME"/flutter && flutter precache --ios
 
 echo "$MC_LOG_PREFIX ========== Build app =========="

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -56,7 +56,7 @@ dev_dependencies:
   flutter_launcher_icons: ^0.12.0
   import_sorter: ^4.6.0
   pedantic: ^1.11.0
-  protoc_plugin: ^20.0.0
+  protoc_plugin: ^20.0.1
 
 flutter_icons:
   ios: true

--- a/flutter/windows/docker/Dockerfile
+++ b/flutter/windows/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN choco install -y --no-progress protoc --version 3.18.1
 RUN python3 -m pip install --user numpy absl-py
 
 RUN dart --disable-analytics && `
-    dart pub global activate protoc_plugin && `
+    dart pub global activate protoc_plugin ^20.0.1 && `
     setx path "%path%;%LOCALAPPDATA%/Pub/Cache/bin"
 
 ENTRYPOINT ["cmd", "/S", "/C"]

--- a/tools/formatter/Dockerfile
+++ b/tools/formatter/Dockerfile
@@ -69,7 +69,7 @@ RUN git config --global --add safe.directory /home/$UNAME/flutter
 ENV PUB_CACHE=/home/mlperf/.pub-cache
 ENV PATH=$PATH:/home/$UNAME/flutter/bin:/home/$UNAME/flutter/bin/cache/dart-sdk/bin:$PUB_CACHE/bin
 RUN flutter doctor -v
-RUN dart pub global activate protoc_plugin && chmod --recursive a=u $PUB_CACHE
+RUN dart pub global activate protoc_plugin ^20.0.1 && chmod --recursive a=u $PUB_CACHE
 RUN apt-get install -y --no-install-recommends protobuf-compiler
 # The /home/mlperf/mobile_app_open directory will be mounted
 RUN git config --global --add safe.directory /home/mlperf/mobile_app_open


### PR DESCRIPTION
A new `protoc_plugin` v21.0.0 is just released and breaks our CI because we use the previous version v20.0.1, which was released 12 months ago (see https://pub.dev/packages/protoc_plugin/versions).

This PR pins the `protoc_plugin` version to v20.0.1.