### PR TITLE
refactor: replace the flag dataset with benchmark_id in main.cc

### DIFF
--- a/flutter/cpp/binary/README.md
+++ b/flutter/cpp/binary/README.md
@@ -1,7 +1,7 @@
 # MLPerf backends
 
 This directory provides a main binary file which can be used to evaluate the
-MLPerf benchmark with a specific set of (backend, dataset).
+MLPerf benchmark with a specific set of (backend, benchmark_id).
 
 ## Build the TFLite backend
 
@@ -13,7 +13,7 @@ bazel build -c opt --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 \
 
 ## Run the TFLite backend
 
-For example, use the following command to run TFLite with the ImageNet dataset:
+For example, use the following command to run TFLite with the `image_classification` benchmark:
 
 1. build the command program `//flutter/cpp/binary:main`
 
@@ -25,42 +25,41 @@ For example, use the following command to run TFLite with the ImageNet dataset:
 2. run it
 
    ```bash
-   bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET
+   bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification
      --mode=SubmissionRun \
      --model_file=<path to the model file> \
      --output_dir=<mlperf output directory>
      ....
    ```
 
-Each set of (backend, dataset) has a different set of arguments, so please use
+Each set of (backend, benchmark_id) has a different set of arguments, so please use
 `--help` argument to check which flags are available. E.g., with
 
 ```bash
-bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET --help
+bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification --help
 ```
 
 we get
 
 ```shell
-usage: bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET <flags>
+usage: bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification <flags>
 Flags:
-  --mode=                                     string  required Mode is one among PerformanceOnly, AccuracyOnly, SubmissionRun.
-  --output_dir=                               string  required The output directory of mlperf.
-  --model_file=                               string  required Path to model file.
-  --images_directory=                         string  required Path to ground truth images.
-  --offset=1                                  int32   required The offset of the first meaningful class in the classification model.
-  --groundtruth_file=                         string  required Path to the imagenet ground truth file.
-  --min_query_count=100                       int32   optional The test will guarantee to run at least this number of samples in performance mode.
-  --min_duration=100                          int32   optional The test will guarantee to run at least this duration in performance mode. The duration is in ms.
-  --single_stream_expected_latency_ns=1000000 int32   optional single_stream_expected_latency_ns
-  --lib_path=                                 string  optional Path to the backend library .so file.
-  --native_lib_path=                          string  optional Path to the additioal .so files for the backend.
-  --scenario=SingleStream                     string  optional Scenario to run the benchmark.
-  --image_width=224                           int32   optional The width of the processed image.
-  --image_height=224                          int32   optional The height of the processed image.
-  --scenario=SingleStream                     string  optional Scenario to run the benchmark.
-  --batch_size=1                              int32   optional Batch size.
-
+  --mode=                                         string  required        Mode is one among PerformanceOnly, AccuracyOnly, SubmissionRun.
+  --output_dir=                                   string  required        The output directory of mlperf.
+  --model_file=                                   string  required        Path to model file.
+  --images_directory=                             string  required        Path to ground truth images.
+  --offset=1                                      int32   required        The offset of the first meaningful class in the classification model.
+  --groundtruth_file=                             string  required        Path to the imagenet ground truth file.
+  --min_query_count=100                           int32   optional        The test will guarantee to run at least this number of samples in performance mode.
+  --min_duration_ms=100                           int32   optional        The test will guarantee to run at least this duration in performance mode. The duration is in ms.
+  --max_duration_ms=600000                        int32   optional        The test will early exit when max duration is reached.The duration is in ms.
+  --single_stream_expected_latency_ns=1000000     int32   optional        A hint used by the loadgen to pre-generate enough samples to meet the minimum test duration.
+  --lib_path=                                     string  optional        Path to the backend library .so file.
+  --native_lib_path=                              string  optional        Path to the additional .so files for the backend.
+  --scenario=SingleStream                         string  optional        Scenario to run the benchmark.
+  --batch_size=1                                  int32   optional        Batch size.
+  --image_width=224                               int32   optional        The width of the processed image.
+  --image_height=224                              int32   optional        The height of the processed image.
 ```
 
 The supported backends and datasets for this binary is listed in the enum

--- a/flutter/ios/ci_scripts/ci_post_clone.sh
+++ b/flutter/ios/ci_scripts/ci_post_clone.sh
@@ -51,7 +51,7 @@ echo "$MC_LOG_PREFIX runner is ${runner}"
 
 echo "$MC_LOG_PREFIX ========== Install dependencies =========="
 
-brew update --quiet
+brew update --quiet || true
 echo "$MC_LOG_PREFIX brew version:" && brew config
 
 # `brew install` failed often due to connection issue so we try several times

--- a/mobile_back_apple/dev-utils/Makefile
+++ b/mobile_back_apple/dev-utils/Makefile
@@ -26,7 +26,7 @@ tflite-build:
 
 tflite-run-ic:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobilenet_edgetpu/mobilenet_edgetpu_224_1.0_float.tflite" \
@@ -39,10 +39,10 @@ tflite-run-ic:
 
 tflite-run-ic-offline:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification_offline \
 		--mode=PerformanceOnly \
 		--scenario=Offline \
-		--batch_size=8 \
+		--batch_size=32 \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobilenet_edgetpu/mobilenet_edgetpu_224_1.0_float.tflite" \
 		--lib_path="bazel-bin/mobile_back_tflite/cpp/backend_tflite/libtflitebackend.so" \
@@ -54,7 +54,7 @@ tflite-run-ic-offline:
 
 tflite-run-od:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL COCO \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL object_detection \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobiledet/mobiledet.tflite" \
@@ -66,7 +66,7 @@ tflite-run-od:
 
 tflite-run-is:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL ADE20K \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL image_segmentation_v2 \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mosaic/mobile_segmenter_r4_argmax_f32.tflite" \
@@ -76,7 +76,7 @@ tflite-run-is:
 
 tflite-run-lu:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL SQUAD \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL natural_language_processing \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobilebert/mobilebert_float_384_gpu.tflite" \
@@ -86,7 +86,7 @@ tflite-run-lu:
 
 tflite-run-sr:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL SNUSR \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL super_resolution \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/edsr_final/converted/edsr_f32b5_fp32.tflite" \
@@ -101,7 +101,7 @@ coreml-build:
 
 coreml-run-ic:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobilenet_edgetpu/MobilenetEdgeTPU.mlmodel" \
@@ -110,10 +110,9 @@ coreml-run-ic:
 		--groundtruth_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/imagenet/imagenet_val.txt" \
 		--offset=1
 
-# batch_size defined here must match with batch_size in coreml_settings.h
 coreml-run-ic-offline:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL IMAGENET \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL image_classification_offline \
 		--mode=PerformanceOnly \
 		--scenario=Offline \
 		--batch_size=32 \
@@ -126,7 +125,7 @@ coreml-run-ic-offline:
 
 coreml-run-od:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL COCO \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL object_detection \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobiledet/MobileDet.mlmodel" \
@@ -138,7 +137,7 @@ coreml-run-od:
 
 coreml-run-is:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL ADE20K \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL image_segmentation_v2 \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mosaic/Mosaic.mlmodel" \
@@ -148,7 +147,7 @@ coreml-run-is:
 
 coreml-run-lu:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL SQUAD \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL natural_language_processing \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/mobilebert/MobileBERT.mlmodel" \
@@ -158,7 +157,7 @@ coreml-run-lu:
 
 coreml-run-sr:
 	cd ${REPO_ROOT_DIR} && \
-	bazel-bin/flutter/cpp/binary/main EXTERNAL SNUSR \
+	bazel-bin/flutter/cpp/binary/main EXTERNAL super_resolution \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
 		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/edsr_final/converted/edsr_f32b5_fp32.mlmodel" \


### PR DESCRIPTION
* Use `benchmark_id` instead of `dataset`. This change is needed if we want to add new tasks which use the same dataset as other tasks (like Image Classification V2 as in https://github.com/mlcommons/mobile_app_open/issues/719)
* Fix an issue where the `batch_size` flag in `main.cc` did not override the value in backend_setting.
