### PR TITLE
chore: update app version to v3.1.0

### DIFF
--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 # version format: <semantic_app_version>+<build_number>.
 # Note: build_number will be set by CI using the CLI option --build-number
-version: 3.0.0+1
+version: 3.1.0+1
 
 environment:
   sdk: ">=2.18.0 <3.0.0"


### PR DESCRIPTION
App v3.0 is released, so all builds from now should be for the v3.1 release.