### PR TITLE
refactor: migrate Samsung pbtxt to use delegate_choice

### DIFF
--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_1200.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_1200.pbtxt
@@ -9,106 +9,134 @@ common_setting {
     name: "4 threads"
   }
 }
+
 benchmark_setting {
   benchmark_id: "image_classification"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "local:///MLPerf_sideload/ic.nnc"
+    model_checksum: "a1f2b667ba702531fb85d83bb4ff4e94"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "local:///MLPerf_sideload/ic.nnc"
-  model_checksum: "a1f2b667ba702531fb85d83bb4ff4e94"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 900000
 }
+
 benchmark_setting {
   benchmark_id: "object_detection"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "local:///MLPerf_sideload/od.nnc"
+    model_checksum: "0d11a82c8b39da82f620dd972caac3f2"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "local:///MLPerf_sideload/od.nnc"
-  model_checksum: "0d11a82c8b39da82f620dd972caac3f2"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "image_segmentation_v1"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Int32"
-  }
-  model_path: "local:///MLPerf_sideload/is.nnc"
-  model_checksum: "e852f29a81cafad37e803a0d1af7c533"
+  delegate_choice: { delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Int32"
+    }
+    model_path: "local:///MLPerf_sideload/is.nnc"
+    model_checksum: "e852f29a81cafad37e803a0d1af7c533" }
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "image_segmentation_v2"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Int32"
+    }
+    model_path: "local:///MLPerf_sideload/sm_uint8.nnc"
+    model_checksum: "34fa011cfbf145ccc06072840974d9a1"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Int32"
-  }
-  model_path: "local:///MLPerf_sideload/sm_uint8.nnc"
-  model_checksum: "34fa011cfbf145ccc06072840974d9a1"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "super_resolution"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "local:///MLPerf_sideload/sr.nnc"
+    model_checksum: "6e725dffed620377b9eff463e106e6dd"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "local:///MLPerf_sideload/sr.nnc"
-  model_checksum: "6e725dffed620377b9eff463e106e6dd"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "image_classification_offline"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  batch_size: 48
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    batch_size: 48
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "local:///MLPerf_sideload/ic_offline.nnc"
+    model_checksum: "a1f2b667ba702531fb85d83bb4ff4e94"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "local:///MLPerf_sideload/ic_offline.nnc"
-  model_checksum: "a1f2b667ba702531fb85d83bb4ff4e94"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2100.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2100.pbtxt
@@ -9,123 +9,158 @@ common_setting {
     name: "4 threads"
   }
 }
+
 benchmark_setting {
   benchmark_id: "image_classification"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic.nnc"
+    model_checksum: "955ef2ac3c134820eab901f3dac9f732"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic.nnc"
-  model_checksum: "955ef2ac3c134820eab901f3dac9f732"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 900000
 }
+
 benchmark_setting {
   benchmark_id: "image_segmentation_v1"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Uint8"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/is.nnc"
+    model_checksum: "b501ed669da753b08a151639798af37e"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Uint8"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/is.nnc"
-  model_checksum: "b501ed669da753b08a151639798af37e"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "image_segmentation_v2"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Uint8"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/sm_uint8.nnc"
+    model_checksum: "483eee2df253ecc135a6e8701cc0c909"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Uint8"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/sm_uint8.nnc"
-  model_checksum: "483eee2df253ecc135a6e8701cc0c909"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "super_resolution"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "local:///MLPerf_sideload/sr.nnc"
+    model_checksum: "6e725dffed620377b9eff463e106e6dd"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "local:///MLPerf_sideload/sr.nnc"
-  model_checksum: "6e725dffed620377b9eff463e106e6dd"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "object_detection"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/od.nnc"
+    model_checksum: "a3c7b5e8d6b978c05807e8926584758c"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/od.nnc"
-  model_checksum: "a3c7b5e8d6b978c05807e8926584758c"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "natural_language_processing"
-  accelerator: "gpu"
-  accelerator_desc: "gpu"
   framework: "ENN"
-  custom_setting {
-    id: "i_type"
-    value: "Int32"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "gpu"
+    custom_setting {
+      id: "i_type"
+      value: "Int32"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/lu.nnc"
+    model_checksum: "215ee3b9224d15dc50b30d56fa7b7396"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/lu.nnc"
-  model_checksum: "215ee3b9224d15dc50b30d56fa7b7396"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "image_classification_offline"
-  accelerator: "npudsp"
-  accelerator_desc: "npu"
   framework: "ENN"
-  batch_size: 8192
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npudsp"
+    accelerator_desc: "npu"
+    batch_size: 8192
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic_offline.nncgo"
+    model_checksum: "c38acf6c66ca32c525c14ce25ead823a"
   }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic_offline.nncgo"
-  model_checksum: "c38acf6c66ca32c525c14ce25ead823a"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2200.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2200.pbtxt
@@ -3,180 +3,209 @@
 
 benchmark_setting {
   benchmark_id: "image_classification"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1001"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1001"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "false"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_single.nnc"
+    model_checksum: "a49175f3f4f37f59780995cec540dbf2"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "false"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_single.nnc"
-  model_checksum: "a49175f3f4f37f59780995cec540dbf2"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 900000
 }
+
 benchmark_setting {
   benchmark_id: "image_segmentation_v2"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1004"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1004"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "extension"
+      value: "false"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "false"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/sm_uint8.nnc"
+    model_checksum: "f715f55818863f371336ad29ecba1183"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "extension"
-    value: "false"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "false"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/sm_uint8.nnc"
-  model_checksum: "f715f55818863f371336ad29ecba1183"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "super_resolution"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1002"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1002"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "true"
+    }
+    model_path: "local:///MLPerf_sideload/sr.nnc"
+    model_checksum: "6e725dffed620377b9eff463e106e6dd"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "true"
-  }
-  model_path: "local:///MLPerf_sideload/sr.nnc"
-  model_checksum: "6e725dffed620377b9eff463e106e6dd"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "object_detection"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1003"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1003"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "false"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/od.nnc"
+    model_checksum: "6b34201b6696fa75311d0d43820e03d2"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "false"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/od.nnc"
-  model_checksum: "6b34201b6696fa75311d0d43820e03d2"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "natural_language_processing"
-  accelerator: "gpu"
-  accelerator_desc: "gpu"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1000"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "gpu"
+    custom_setting {
+      id: "preset"
+      value: "1000"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Int32"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "false"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "false"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/mobile_bert_gpu.nnc"
+    model_checksum: "d98dfcc37ad33fa7081d6fbb5bc6ddd1"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Int32"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "false"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "false"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/mobile_bert_gpu.nnc"
-  model_checksum: "d98dfcc37ad33fa7081d6fbb5bc6ddd1"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
+
 benchmark_setting {
   benchmark_id: "image_classification_offline"
-  accelerator: "samsung_npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  batch_size: 8192
-  custom_setting {
-    id: "scenario"
-    value: "offline"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "npu"
+    batch_size: 8192
+    custom_setting {
+      id: "scenario"
+      value: "offline"
+    }
+    custom_setting {
+      id: "preset"
+      value: "1002"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "false"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "false"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_offline.nnc"
+    model_checksum: "8832370c770fa820dfde83e039e3243c"
   }
-  custom_setting {
-    id: "preset"
-    value: "1002"
-  }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "false"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "false"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_offline.nnc"
-  model_checksum: "8832370c770fa820dfde83e039e3243c"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2300.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2300.pbtxt
@@ -12,185 +12,209 @@ common_setting {
 
 benchmark_setting {
   benchmark_id: "image_classification"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1009"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1009"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "true"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_single_fence.nnc"
+    model_checksum: "a451da1f48b1fad01c17fb7a49e5822e"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "true"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_single_fence.nnc"
-  model_checksum: "a451da1f48b1fad01c17fb7a49e5822e"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 500000
 }
 
 benchmark_setting {
   benchmark_id: "image_segmentation_v2"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1009"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1009"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "true"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/sm_uint8_fence.nnc"
+    model_checksum: "08fa7b354f82140a8863fed57c2d499b"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "true"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/sm_uint8_fence.nnc"
-  model_checksum: "08fa7b354f82140a8863fed57c2d499b"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
 
 benchmark_setting {
   benchmark_id: "object_detection"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1009"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1009"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "true"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/od_fence.nnc"
+    model_checksum: "8a7e1808446072545c990f3d219255c6"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "true"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/od_fence.nnc"
-  model_checksum: "8a7e1808446072545c990f3d219255c6"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
 
 benchmark_setting {
   benchmark_id: "super_resolution"
-  accelerator: "samsung_npu"
-  accelerator_desc: "NPU"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1002"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "NPU"
+    custom_setting {
+      id: "preset"
+      value: "1002"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "true"
+    }
+    model_path: "local:///MLPerf_sideload/sr.nnc"
+    model_checksum: "6e725dffed620377b9eff463e106e6dd"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "true"
-  }
-  model_path: "local:///MLPerf_sideload/sr.nnc"
-  model_checksum: "6e725dffed620377b9eff463e106e6dd"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
 
 benchmark_setting {
   benchmark_id: "natural_language_processing"
-  accelerator: "npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  custom_setting {
-    id: "preset"
-    value: "1009"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "npu"
+    accelerator_desc: "npu"
+    custom_setting {
+      id: "preset"
+      value: "1009"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Int32"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "true"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "true"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/mobile_bert_fence.nnc"
+    model_checksum: "5fb666b684a9bd0b68d497128b990137"
   }
-  custom_setting {
-    id: "i_type"
-    value: "Int32"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "true"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "true"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/mobile_bert_fence.nnc"
-  model_checksum: "5fb666b684a9bd0b68d497128b990137"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }
 
 benchmark_setting {
   benchmark_id: "image_classification_offline"
-  accelerator: "samsung_npu"
-  accelerator_desc: "npu"
   framework: "ENN"
-  batch_size: 8192
-  custom_setting {
-    id: "scenario"
-    value: "offline"
+  delegate_choice: {
+    delegate_name: "ENN_NPU"
+    accelerator_name: "samsung_npu"
+    accelerator_desc: "npu"
+    batch_size: 8192
+    custom_setting {
+      id: "scenario"
+      value: "offline"
+    }
+    custom_setting {
+      id: "preset"
+      value: "1002"
+    }
+    custom_setting {
+      id: "i_type"
+      value: "Uint8"
+    }
+    custom_setting {
+      id: "o_type"
+      value: "Float32"
+    }
+    custom_setting {
+      id: "extension"
+      value: "false"
+    }
+    custom_setting {
+      id: "lazy_mode"
+      value: "false"
+    }
+    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_offline.nnc"
+    model_checksum: "6885f281a3d7a7ec3549d629dff8c8ac"
   }
-  custom_setting {
-    id: "preset"
-    value: "1002"
-  }
-  custom_setting {
-    id: "i_type"
-    value: "Uint8"
-  }
-  custom_setting {
-    id: "o_type"
-    value: "Float32"
-  }
-  custom_setting {
-    id: "extension"
-    value: "false"
-  }
-  custom_setting {
-    id: "lazy_mode"
-    value: "false"
-  }
-  model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_offline.nnc"
-  model_checksum: "6885f281a3d7a7ec3549d629dff8c8ac"
+  delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
 }


### PR DESCRIPTION
Part of #748 

@AhmedTElthakeb I updated the Samsung `*.pbtxt` files to use `delegate_choice`. Please check the updated files and push any changes you want directly to this PR. Noted that I don't have a Samsung device to test the settings.