### PR TITLE
ci: fix disk space issue on App Build workflow

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -13,8 +13,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
@@ -62,6 +61,7 @@ jobs:
           aws s3 --endpoint-url=https://s3.us-east-1.lyvecloud.seagate.com \
           cp --quiet s3://mlcommons-mobile-wg-private/libs/v3.1/samsung_libs_v3.1.zip /tmp/ && \
           unzip -P ${AWS_SECRET_ACCESS_KEY} /tmp/samsung_libs_v3.1.zip -d /tmp/samsung_libs_v3.1 && \
+          rm /tmp/samsung_libs_v3.1.zip && \
           mkdir -p mobile_back_samsung/samsung/lib/internal && \
           mv /tmp/samsung_libs_v3.1/internal/* mobile_back_samsung/samsung/lib/internal/
       - name: Download QTI libraries
@@ -72,13 +72,12 @@ jobs:
           aws s3 --endpoint-url=https://s3.us-east-1.lyvecloud.seagate.com \
           cp --quiet s3://mlcommons-mobile-wg-private/libs/v3.0/snpe-2.7.0.4264-linux.zip /tmp/ && \
           unzip -P ${AWS_SECRET_ACCESS_KEY} /tmp/snpe-2.7.0.4264-linux.zip -d /tmp/snpe-2.7.0.4264-linux && \
+          rm /tmp/snpe-2.7.0.4264-linux.zip && \
           mv /tmp/snpe-2.7.0.4264-linux/snpe-2.7.0.4264 mobile_back_qti/
       - name: Cache bazel
         uses: actions/cache@v3
         with:
-          path: |
-            /tmp/bazel_output
-            /tmp/bazel_cache
+          path: /tmp/bazel_cache
           key: ${{ runner.os }}-bazel_cache-${{ hashFiles('**/BUILD', '**/WORKSPACE') }}
           restore-keys: ${{ runner.os }}-bazel_cache-
       - name: Run Flutter unit tests

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -39,9 +39,7 @@ jobs:
       - name: Cache bazel
         uses: actions/cache@v3
         with:
-          path: |
-            /tmp/bazel_output
-            /tmp/bazel_cache
+          path: /tmp/bazel_cache
           key: ${{ runner.os }}-bazel_cache-${{ hashFiles('**/BUILD', '**/WORKSPACE') }}
           restore-keys: ${{ runner.os }}-bazel_cache-
       - name: Build iOS app

--- a/flutter/android/docker/Dockerfile
+++ b/flutter/android/docker/Dockerfile
@@ -6,7 +6,8 @@ FROM ubuntu:20.04
 # JDK package downloads ~500 MB from slow mirrors, which can take a lot of time,
 #   so a separate layer for it makes image rebuild faster in case we change any other dependencies.
 RUN apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    openjdk-11-jdk-headless
+    openjdk-11-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
 RUN apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     apt-transport-https \
@@ -18,7 +19,8 @@ RUN apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install 
     make \
     protobuf-compiler \
     python3 \
-    python3-pip
+    python3-pip && \
+    rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python3 -m pip install numpy absl-py
 

--- a/tools/scanner/Dockerfile
+++ b/tools/scanner/Dockerfile
@@ -1,13 +1,16 @@
 ARG BASE_DOCKER_IMAGE_TAG
 FROM $BASE_DOCKER_IMAGE_TAG
 
-RUN apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends unzip
+# Install minimum recommended Java version
+RUN apt-get update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    openjdk-17-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG SONAR_SCANNER_DIR=$HOME/.sonar
 
 # Install sonar-scanner
 # Check for newer version here: https://binaries.sonarsource.com/?prefix=Distribution/sonar-scanner-cli/
-ENV SONAR_SCANNER_VERSION=4.8.0.2856
+ENV SONAR_SCANNER_VERSION=5.0.1.3006
 RUN curl --proto '=https' --create-dirs -sSLo $SONAR_SCANNER_DIR/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
 RUN unzip -qq -o $SONAR_SCANNER_DIR/sonar-scanner.zip -d $SONAR_SCANNER_DIR/
 ENV PATH=$PATH:$SONAR_SCANNER_DIR/sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin


### PR DESCRIPTION
A GitHub Actions runner has limited disk space and some time produces warnings about no disk space.
This PR frees up disk space by clearing cached and temp files.