### PR TITLE
fix: delayed UI on app start

### DIFF
--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -108,7 +108,7 @@ class BenchmarkState extends ChangeNotifier {
     notifyListeners();
     try {
       await setTaskConfig(name: _store.chosenConfigurationName);
-      await deferredLoadResources();
+      deferredLoadResources();
     } catch (e, trace) {
       print("can't load resources: $e");
       print(trace);
@@ -121,7 +121,8 @@ class BenchmarkState extends ChangeNotifier {
 
   // Start loading resources in background.
   // Return type 'void' is intended, this function must not be awaited.
-  Future<void> deferredLoadResources() async {
+  // ignore: avoid_void_async
+  void deferredLoadResources() async {
     try {
       await loadResources();
     } catch (e, trace) {
@@ -172,7 +173,7 @@ class BenchmarkState extends ChangeNotifier {
         state.resourceManager.applicationDirectory, state.resourceManager);
     try {
       await state.setTaskConfig(name: store.chosenConfigurationName);
-      await state.deferredLoadResources();
+      state.deferredLoadResources();
     } catch (e, trace) {
       print("can't load resources: $e");
       print(trace);

--- a/flutter/lib/ui/root/resource_error_screen.dart
+++ b/flutter/lib/ui/root/resource_error_screen.dart
@@ -94,7 +94,7 @@ class ResourceErrorScreen extends StatelessWidget {
                           try {
                             await state.setTaskConfig(
                                 name: store.chosenConfigurationName);
-                            await state.deferredLoadResources();
+                            state.deferredLoadResources();
                           } catch (e, trace) {
                             print("can't change task config: $e");
                             print(trace);


### PR DESCRIPTION
This PR resolves an issue, where the app shows a white or black screen until all resources downloaded, instead of showing a downloading progress.