### PR TITLE
ci: upload release APK

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -142,4 +142,6 @@ jobs:
           aws s3 --endpoint-url=https://s3.us-east-1.lyvecloud.seagate.com \
           cp --quiet output/android-apks/test-main.apk s3://mlcommons-mobile-mlperf-arm/builds/${{ github.run_number }}/ && \
           aws s3 --endpoint-url=https://s3.us-east-1.lyvecloud.seagate.com \
-          cp --quiet output/android-apks/test-helper.apk s3://mlcommons-mobile-mlperf-arm/builds/${{ github.run_number }}/
+          cp --quiet output/android-apks/test-helper.apk s3://mlcommons-mobile-mlperf-arm/builds/${{ github.run_number }}/ && \
+          aws s3 --endpoint-url=https://s3.us-east-1.lyvecloud.seagate.com \
+          cp --quiet flutter/build/app/outputs/flutter-apk/app-release.apk s3://mlcommons-mobile-mlperf-arm/builds/${{ github.run_number }}/

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -48,6 +48,13 @@ jobs:
           BAZEL_CACHE_ARG: "--disk_cache=/tmp/bazel_cache"
         run: |
           cd flutter/ios/ci_scripts/ && bash ci_post_clone.sh
-      - name: Run iOS tests
+      - name: Run iOS unit tests
         run: |
-          open -a Simulator && make flutter/test
+          make flutter/test/unit
+      - name: Build iOS integration tests
+        run: |
+          cd flutter && flutter --no-version-check build ios --config-only integration_test/first_test.dart
+      - name: Run iOS integration tests
+        run: |
+          open -a Simulator
+          make flutter/test/integration

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: Build and test iOS app
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 120
     env:
       PERF_TEST: true

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: Build and test iOS app
     # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 120
     env:
       PERF_TEST: true

--- a/flutter/ios/ci_scripts/ci_post_clone.sh
+++ b/flutter/ios/ci_scripts/ci_post_clone.sh
@@ -66,8 +66,8 @@ echo "$MC_LOG_PREFIX cocoapods version:" && pod --version
 
 brew install python@3.11 || brew link --overwrite python@3.11
 echo "$MC_LOG_PREFIX python version:" && python3 --version
-pip3 install --upgrade pip
-pip3 install \
+python3 -m pip install --upgrade pip
+python3 -m pip install \
   "numpy>=1.23,<2.0" \
   "absl-py>=1.3,<2.0"
 


### PR DESCRIPTION
Part of https://github.com/mlcommons/mobile_app_open/issues/588

Upload release APKs to the MLCommons cloud storage for running tests on physical devices.
The previous PR https://github.com/mlcommons/mobile_app_open/pull/771 uploaded a debug APK for integration test. This PR adds the release APK.