### PR TITLE
ci: run GitHub workflows on any submission branches

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -2,7 +2,7 @@ name: App Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -2,7 +2,7 @@ name: Code Analysis
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -2,8 +2,7 @@ name: Format & lint
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -2,8 +2,7 @@ name: iOS Tests
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,8 +2,7 @@ name: Unit tests
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
Currently, we run the workflows on PR and merge into `master`.
Now the workflows will also run on any `submission-v*` branches, so we can use the APK built by CI for release.