### PR TITLE
ui: move Privacy Policy and EULA from settings screen to app drawer

### DIFF
--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -108,3 +108,8 @@ class BackendId {
     apple,
   ];
 }
+
+class Url {
+  static const privacyPolicy = 'https://mlcommons.org/mobile_privacy';
+  static const eula = 'https://mlcommons.org/mobile_eula';
+}

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -63,7 +63,7 @@
   "settingsKeepLogsSubtitle": "Keep loadgen logs of future runs.\nThis option doesn't affect past logs.",
   "settingsCooldown": "Cooldown",
   "settingsCooldownSubtitle": "Pause <cooldownPause> minutes before running each benchmark to avoid thermal throttling.",
-  "settingsPrivacyPolicy": "Privacy policy",
+  "settingsPrivacyPolicy": "Privacy Policy",
   "settingsEula": "End User License Agreement",
   "settingsTaskConfigTitle": "Task configuration",
   "settingsTaskConfigInternetResource": "downloadable",

--- a/flutter/lib/ui/home/app_drawer.dart
+++ b/flutter/lib/ui/home/app_drawer.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/firebase/firebase_manager.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/ui/config/config_screen.dart';
@@ -16,12 +19,7 @@ class AppDrawer extends StatelessWidget {
     final header = buildHeader(context);
     final menuList = buildMenuList(context);
     return Drawer(
-      // Add a ListView to the drawer. This ensures the user can scroll
-      // through the options in the drawer if there isn't enough vertical
-      // space to fit everything.
-      child: ListView(
-        // Important: Remove any padding from the ListView.
-        padding: EdgeInsets.zero,
+      child: Column(
         children: [header] + menuList,
       ),
     );
@@ -106,6 +104,16 @@ class AppDrawer extends StatelessWidget {
                 builder: (context) => const AboutScreen(),
               ));
         },
+      ),
+      const Spacer(),
+      const Divider(),
+      ListTile(
+        title: Text(l10n.settingsPrivacyPolicy),
+        onTap: () => launchUrl(Uri.parse(Url.privacyPolicy)),
+      ),
+      ListTile(
+        title: Text(l10n.settingsEula),
+        onTap: () => launchUrl(Uri.parse(Url.eula)),
       ),
     ];
   }

--- a/flutter/lib/ui/settings/settings_screen.dart
+++ b/flutter/lib/ui/settings/settings_screen.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:mlperfbench/benchmark/run_mode.dart';
 import 'package:mlperfbench/benchmark/state.dart';
@@ -170,19 +169,6 @@ class _SettingsScreen extends State<SettingsScreen> {
             ),
             const Divider(),
             crashlyticsSwitch,
-            const Divider(),
-            ListTile(
-              title: Text(l10n.settingsPrivacyPolicy),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () =>
-                  launchUrl(Uri.parse('https://mlcommons.org/mobile_privacy')),
-            ),
-            ListTile(
-              title: Text(l10n.settingsEula),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () =>
-                  launchUrl(Uri.parse('https://mlcommons.org/mobile_eula')),
-            ),
             const Divider(),
             ListTile(
               title: Padding(


### PR DESCRIPTION
Part of #806 

<img src="https://github.com/mlcommons/mobile_app_open/assets/85728587/7274bd56-42fa-45d4-87f4-718871132b33" width="320">