### PR TITLE
ui: new result screen

### DIFF
--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -2,11 +2,10 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mlperfbench/ui/home/benchmark_start_screen.dart';
+import 'package:mlperfbench/app_constants.dart';
 import 'package:provider/provider.dart';
 
 import 'package:mlperfbench/benchmark/state.dart';
-import 'package:mlperfbench/ui/home/benchmark_result_screen.dart';
 import 'package:mlperfbench/data/extended_result.dart';
 import 'package:mlperfbench/resources/result_manager.dart' as result_manager;
 import 'package:mlperfbench/resources/resource_manager.dart'
@@ -56,21 +55,21 @@ Future<void> validateSettings(WidgetTester tester) async {
 }
 
 Future<void> runBenchmarks(WidgetTester tester) async {
-  const runTimeLimitMinutes = 30;
   const downloadTimeLimitMinutes = 20;
+  const runTimeLimitMinutes = 30;
 
   var goButtonIsPresented = await waitFor(
-      tester, downloadTimeLimitMinutes, const Key(MainKeys.goButton));
+      tester, downloadTimeLimitMinutes, const Key(WidgetKeys.goButton));
 
   expect(goButtonIsPresented, true,
       reason: 'Problems with downloading of datasets or models');
-  final goButton = find.byKey(const Key(MainKeys.goButton));
+  final goButton = find.byKey(const Key(WidgetKeys.goButton));
   await tester.tap(goButton);
 
-  var scrollButtonIsPresented = await waitFor(
-      tester, runTimeLimitMinutes, const Key(ResultKeys.scrollResultsButton));
+  var totalScoreIsPresented = await waitFor(
+      tester, runTimeLimitMinutes, const Key(WidgetKeys.totalScoreCircle));
 
-  expect(scrollButtonIsPresented, true, reason: 'Test results were not found');
+  expect(totalScoreIsPresented, true, reason: 'Result screen is not presented');
 }
 
 Future<ExtendedResult> obtainResult() async {

--- a/flutter/ios/ci_scripts/ci_post_clone.sh
+++ b/flutter/ios/ci_scripts/ci_post_clone.sh
@@ -64,7 +64,6 @@ echo "$MC_LOG_PREFIX protobuf version:" && protoc --version
 brew install cocoapods || brew install cocoapods || brew install cocoapods
 echo "$MC_LOG_PREFIX cocoapods version:" && pod --version
 
-brew install python@3.11 || brew link --overwrite python@3.11
 echo "$MC_LOG_PREFIX python version:" && python3 --version
 python3 -m pip install --upgrade pip
 python3 -m pip install \

--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -17,6 +17,8 @@ class AppColors {
   static const lightText = Colors.white;
   static const lightRedText = Color.fromARGB(255, 255, 120, 100);
   static const darkText = Colors.black;
+  static const resultValid = Colors.indigo;
+  static const resultInvalid = Colors.red;
   static const darkRedText = Colors.red;
   static const lightBlue = Color(0XFF2C92CB);
   static const darkBlue = Color(0xFF0B3A61);

--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -18,7 +18,8 @@ class AppColors {
   static const lightRedText = Color.fromARGB(255, 255, 120, 100);
   static const darkText = Colors.black;
   static const darkRedText = Colors.red;
-  static const darBlue = Color(0xFF0B3A61);
+  static const lightBlue = Color(0XFF2C92CB);
+  static const darkBlue = Color(0xFF0B3A61);
 
   static const dialogBackground = Colors.white;
   static const snackBarBackground = Color(0xFFEDEDED);

--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -46,11 +46,6 @@ class AppColors {
 
   static const runBenchmarkRectangle = Color(0xFF0DB526);
 
-  static List<Color> get runBenchmarkCircleGradient => [
-        Color.lerp(const Color(0xFF0DB526), Colors.white, 0.65)!,
-        const Color(0xFF0DB526), // 0DB526
-      ];
-
   static List<Color> get progressScreenGradient => DartDefine.isOfficialBuild
       ? [const Color(0xff3189E2), const Color(0xff0B4A7F)]
       : [Colors.brown.shade400, Colors.brown];
@@ -78,6 +73,10 @@ class AppColors {
   static const shareRectangle = Colors.green;
 
   static Color get shareTextButton => Colors.blue.shade900;
+}
+
+class WidgetSizes {
+  static const circleWidthFactor = 0.32;
 }
 
 class BenchmarkId {

--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -13,6 +13,12 @@ class DartDefine {
       String.fromEnvironment('FLUTTER_DATA_FOLDER');
 }
 
+class WidgetKeys {
+  // list of widget keys that need to be accessed in the test code
+  static const String goButton = 'goButton';
+  static const String totalScoreCircle = 'totalScoreCircle';
+}
+
 class AppColors {
   static const lightText = Colors.white;
   static const lightRedText = Color.fromARGB(255, 255, 120, 100);

--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -20,6 +20,7 @@ class AppColors {
   static const darkRedText = Colors.red;
   static const lightBlue = Color(0XFF2C92CB);
   static const darkBlue = Color(0xFF0B3A61);
+  static const mediumBlue = Color(0xFF135384);
 
   static const dialogBackground = Colors.white;
   static const snackBarBackground = Color(0xFFEDEDED);

--- a/flutter/lib/data/environment/environment_info.dart
+++ b/flutter/lib/data/environment/environment_info.dart
@@ -46,6 +46,27 @@ class EnvironmentInfo {
       _$EnvironmentInfoFromJson(json);
 
   Map<String, dynamic> toJson() => _$EnvironmentInfoToJson(this);
+
+  String get modelDescription {
+    switch (platform) {
+      case EnvPlatform.android:
+        final android = value.android;
+        if (android == null) {
+          return 'Unknown Android device';
+        }
+        return '${android.manufacturer} ${android.modelName}';
+      case EnvPlatform.ios:
+        final ios = value.ios;
+        if (ios == null) {
+          return 'Unknown iOS device';
+        }
+        return 'Apple ${ios.modelName}';
+      case EnvPlatform.windows:
+        return 'PC';
+      default:
+        return '';
+    }
+  }
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)

--- a/flutter/lib/data/result_filter.dart
+++ b/flutter/lib/data/result_filter.dart
@@ -21,6 +21,9 @@ class ResultFilter {
   ResultFilter();
 
   bool match(ExtendedResult result) {
+    if (result.results.isEmpty) {
+      return false;
+    }
     String? resultDeviceModel;
     String? resultManufacturer;
     String? resultSoc;

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -94,6 +94,7 @@
   "dialogContentOfflineWarning": "Offline mode is enabled but following internet resources are defined in the configuration. Do you want to continue?",
   "dialogContentMissingFiles": "Selected datasets directory does not contain files for following benchmarks:",
   "dialogContentChecksumError": "The following files failed checksum validation:",
+  "dialogContentNoSelectedBenchmarkError": "Please select at least one benchmark.",
 
   "benchNameImageClassification": "Image Classification",
   "benchNameObjectDetection": "Object detection",

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -86,7 +86,8 @@
   "settingsClearCacheConfirm": "All loaded resources will be deleted and downloaded again. Continue?",
   "settingsUnableSpecifyConfiguration": "Could not specify until benchmarks is running or content is loading",
 
-  "dialogTitleError": "Errors",
+  "dialogTitleWarning": "Warning",
+  "dialogTitleError": "Error",
   "dialogTitleSuccess": "Success",
   "dialogOk": "Ok",
   "dialogCancel": "Cancel",

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -36,9 +36,7 @@
   "resultsTitleAccuracy": "Results",
   "resultsTabTitlePerformance": "Performance",
   "resultsTabTitleAccuracy": "Accuracy",
-  "resultsTitleDetails": "Detailed Results",
-  "resultsButtonTestAgain": "Test Again",
-  "resultsButtonShare": "Share This Result",
+  "resultsDeleteConfirm": "Delete this results?",
   "resultsNotAvailable": "N/A",
   "resultsBatchSize": "Batches: <batchSize>",
 

--- a/flutter/lib/resources/result_manager.dart
+++ b/flutter/lib/resources/result_manager.dart
@@ -82,6 +82,16 @@ class ResultManager {
     return File('${_resultsDir.path}/$_submissionFileName');
   }
 
+  Future<void> deleteLastResult() async {
+    if (localResults.isNotEmpty) {
+      await deleteResult(localResults.last);
+    }
+    final submissionFile = getSubmissionFile();
+    if (await submissionFile.exists()) {
+      await submissionFile.delete();
+    }
+  }
+
   ExtendedResult getLastResult() {
     return localResults.last;
   }

--- a/flutter/lib/ui/error_dialog.dart
+++ b/flutter/lib/ui/error_dialog.dart
@@ -1,14 +1,30 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_svg/svg.dart';
-
 import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
-import 'package:mlperfbench/ui/icons.dart';
 
-Future<void> showPopupDialog(BuildContext context, String header,
-    SvgPicture? icon, List<String> errors) async {
-  final stringResources = AppLocalizations.of(context);
+enum DialogTypeEnum { error, warning, success }
+
+Future<void> _showPopupDialog(BuildContext context, DialogTypeEnum type,
+    String title, List<String> messages) async {
+  final l10n = AppLocalizations.of(context);
+
+  Icon? icon;
+  Color titleColor;
+  switch (type) {
+    case DialogTypeEnum.error:
+      icon = const Icon(Icons.error, color: Colors.red);
+      titleColor = Colors.red;
+      break;
+    case DialogTypeEnum.warning:
+      icon = const Icon(Icons.warning, color: Colors.yellow);
+      titleColor = Colors.yellow;
+      break;
+    case DialogTypeEnum.success:
+      icon = const Icon(Icons.done, color: Colors.green);
+      titleColor = Colors.green;
+      break;
+  }
 
   await showDialog(
     context: context,
@@ -18,15 +34,17 @@ Future<void> showPopupDialog(BuildContext context, String header,
         backgroundColor: AppColors.dialogBackground,
         titlePadding: const EdgeInsets.all(10),
         contentPadding: const EdgeInsets.fromLTRB(15, 10, 10, 10),
-        title:
-            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-          Text(header),
-          Align(alignment: Alignment.topRight, child: icon),
-        ]),
+        title: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(title, style: TextStyle(color: titleColor)),
+            Align(alignment: Alignment.topRight, child: icon),
+          ],
+        ),
         content: SingleChildScrollView(
           child: ListBody(
             children: [
-              ...errors.map((e) => Text(
+              ...messages.map((e) => Text(
                     e,
                     style: const TextStyle(fontSize: 14),
                   ))
@@ -36,22 +54,30 @@ Future<void> showPopupDialog(BuildContext context, String header,
         actions: [
           TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: Text(stringResources.dialogOk))
+              child: Text(l10n.dialogOk))
         ],
       );
     },
   );
 }
 
-Future<void> showErrorDialog(BuildContext context, List<String> errors) async {
-  final stringResources = AppLocalizations.of(context);
-  await showPopupDialog(
-      context, stringResources.dialogTitleError, AppIcons.error, errors);
+Future<void> showWarningDialog(
+    BuildContext context, List<String> messages) async {
+  final l10n = AppLocalizations.of(context);
+  await _showPopupDialog(
+      context, DialogTypeEnum.warning, l10n.dialogTitleWarning, messages);
+}
+
+Future<void> showErrorDialog(
+    BuildContext context, List<String> messages) async {
+  final l10n = AppLocalizations.of(context);
+  await _showPopupDialog(
+      context, DialogTypeEnum.error, l10n.dialogTitleError, messages);
 }
 
 Future<void> showSuccessDialog(
-    BuildContext context, List<String> errors) async {
-  final stringResources = AppLocalizations.of(context);
-  await showPopupDialog(
-      context, stringResources.dialogTitleSuccess, null, errors);
+    BuildContext context, List<String> messages) async {
+  final l10n = AppLocalizations.of(context);
+  await _showPopupDialog(
+      context, DialogTypeEnum.success, l10n.dialogTitleSuccess, messages);
 }

--- a/flutter/lib/ui/history/result_details_screen.dart
+++ b/flutter/lib/ui/history/result_details_screen.dart
@@ -75,7 +75,7 @@ class _DetailsScreen extends State<DetailsScreen> {
         .replaceFirst('<buildType>', appVersionType);
 
     final utils = HistoryHelperUtils(l10n);
-    final modelDescription = utils.makeModelDescription(res.environmentInfo);
+    final modelDescription = res.environmentInfo.modelDescription;
     final socDescription = utils.makeSocName(state, res.environmentInfo);
 
     return [

--- a/flutter/lib/ui/history/utils.dart
+++ b/flutter/lib/ui/history/utils.dart
@@ -129,27 +129,6 @@ class HistoryHelperUtils {
     );
   }
 
-  String makeModelDescription(EnvironmentInfo info) {
-    switch (info.platform) {
-      case EnvPlatform.android:
-        final android = info.value.android;
-        if (android == null) {
-          return 'Unknown Android device';
-        }
-        return '${android.manufacturer} ${android.modelName}';
-      case EnvPlatform.ios:
-        final ios = info.value.ios;
-        if (ios == null) {
-          return 'Unknown iOS device';
-        }
-        return 'Apple ${ios.modelName}';
-      case EnvPlatform.windows:
-        return 'PC';
-      default:
-        return '';
-    }
-  }
-
   String makeSocName(BenchmarkState state, EnvironmentInfo info) {
     switch (info.platform) {
       case EnvPlatform.android:

--- a/flutter/lib/ui/home/benchmark_config_screen.dart
+++ b/flutter/lib/ui/home/benchmark_config_screen.dart
@@ -19,7 +19,6 @@ class BenchmarkConfigScreen extends StatefulWidget {
 class _BenchmarkConfigScreen extends State<BenchmarkConfigScreen> {
   late BenchmarkState state;
   late AppLocalizations l10n;
-  late double pictureEdgeSize;
 
   @override
   void dispose() {
@@ -31,7 +30,6 @@ class _BenchmarkConfigScreen extends State<BenchmarkConfigScreen> {
   Widget build(BuildContext context) {
     state = context.watch<BenchmarkState>();
     l10n = AppLocalizations.of(context);
-    pictureEdgeSize = 0.1 * MediaQuery.of(context).size.width;
     final childrenList = <Widget>[];
 
     for (var benchmark in state.benchmarks) {
@@ -74,27 +72,36 @@ class _BenchmarkConfigScreen extends State<BenchmarkConfigScreen> {
   }
 
   Widget _listTile(Benchmark benchmark) {
+    final leadingWidth = 0.12 * MediaQuery.of(context).size.width;
+    final subtitleWidth = 0.70 * MediaQuery.of(context).size.width;
+    final trailingWidth = 0.28 * MediaQuery.of(context).size.width;
     return ListTile(
       leading: SizedBox(
-          width: pictureEdgeSize,
-          height: pictureEdgeSize,
+          width: leadingWidth,
+          height: leadingWidth,
           child: benchmark.info.icon),
       title: _name(benchmark),
-      subtitle: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _description(benchmark),
-          _delegateChoice(benchmark),
-        ],
+      subtitle: SizedBox(
+        width: subtitleWidth,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _backendDescription(benchmark),
+            _delegateChoice(benchmark),
+          ],
+        ),
       ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: [
-          _activeToggle(benchmark),
-          _infoButton(benchmark),
-        ],
+      trailing: SizedBox(
+        width: trailingWidth,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _activeToggle(benchmark),
+            _infoButton(benchmark),
+          ],
+        ),
       ),
     );
   }
@@ -103,7 +110,7 @@ class _BenchmarkConfigScreen extends State<BenchmarkConfigScreen> {
     return Text(benchmark.info.taskName);
   }
 
-  Widget _description(Benchmark benchmark) {
+  Widget _backendDescription(Benchmark benchmark) {
     return Padding(
       padding: const EdgeInsets.only(top: 8),
       child: Text(benchmark.backendRequestDescription),
@@ -154,6 +161,7 @@ class _BenchmarkConfigScreen extends State<BenchmarkConfigScreen> {
             }));
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         const Text('Delegate:'),
         const SizedBox(width: 4),

--- a/flutter/lib/ui/home/benchmark_config_screen.dart
+++ b/flutter/lib/ui/home/benchmark_config_screen.dart
@@ -44,8 +44,8 @@ class _BenchmarkConfigScreen extends State<BenchmarkConfigScreen> {
       appBar: PreferredSize(
         preferredSize: const Size.fromHeight(32.0),
         child: AppBar(
-          shape: Border.all(color: AppColors.darBlue),
-          backgroundColor: AppColors.darBlue,
+          shape: Border.all(color: AppColors.darkBlue),
+          backgroundColor: AppColors.darkBlue,
           elevation: 0,
           title: _header(),
         ),

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -114,7 +114,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       );
     }
     Widget testAgainButton = IconButton(
-      icon: const Icon(Icons.replay),
+      icon: const Icon(Icons.restart_alt),
       color: Colors.white,
       onPressed: () async {
         try {

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -12,8 +12,6 @@ import 'package:mlperfbench/ui/home/benchmark_info_button.dart';
 import 'package:mlperfbench/ui/home/benchmark_running_screen.dart';
 import 'package:mlperfbench/ui/home/result_circle.dart';
 import 'package:mlperfbench/ui/home/share_button.dart';
-import 'package:mlperfbench/ui/icons.dart' as app_icons;
-import 'package:mlperfbench/ui/page_constraints.dart';
 
 enum _ScreenMode { performance, accuracy }
 
@@ -225,6 +223,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 summarySection,
+                const SizedBox(height: 20),
                 detailSection,
               ],
             ),
@@ -237,22 +236,28 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
   Widget _summarySection(
       BuildContext context, AppLocalizations l10n, BenchmarkState state) {
     return Container(
-      color: AppColors.appBarBackground,
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            AppColors.lightBlue,
+            AppColors.darkBlue,
+          ],
+        ),
+      ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          SizedBox(
-            width: MediaQuery.of(context).size.width * 0.75,
-            child: TabBar(
-              controller: _tabController,
-              indicator: const UnderlineTabIndicator(),
-              indicatorSize: TabBarIndicatorSize.label,
-              tabs: [
-                Tab(text: l10n.resultsTabTitlePerformance),
-                Tab(text: l10n.resultsTabTitleAccuracy),
-              ],
-            ),
+          TabBar(
+            controller: _tabController,
+            indicator: const UnderlineTabIndicator(),
+            indicatorSize: TabBarIndicatorSize.label,
+            tabs: [
+              Tab(text: l10n.resultsTabTitlePerformance),
+              Tab(text: l10n.resultsTabTitleAccuracy),
+            ],
           ),
           ResultCircle(state.result),
         ],

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -24,17 +24,11 @@ class BenchmarkResultScreen extends StatefulWidget {
   State<BenchmarkResultScreen> createState() => _BenchmarkResultScreenState();
 }
 
-class ResultKeys {
-  // list of widget keys that need to be accessed in the test code
-  static const String scrollResultsButton = 'scrollResultsButton';
-}
-
 class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     with SingleTickerProviderStateMixin {
   _ScreenMode _screenMode = _ScreenMode.performance;
 
   late final TabController _tabController;
-  late final ScrollController _scrollController;
 
   late AppLocalizations l10n;
   late BenchmarkState state;
@@ -54,13 +48,11 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
         }
       }
     });
-    _scrollController = ScrollController();
   }
 
   @override
   void dispose() {
     _tabController.dispose();
-    _scrollController.dispose();
     super.dispose();
   }
 
@@ -90,7 +82,6 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
         builder: (context, constraint) {
           return SingleChildScrollView(
             physics: const ClampingScrollPhysics(),
-            controller: _scrollController,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
@@ -185,7 +176,10 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
               Tab(text: l10n.resultsTabTitleAccuracy),
             ],
           ),
-          ResultCircle(state.result),
+          ResultCircle(
+            key: const Key(WidgetKeys.totalScoreCircle),
+            state.result,
+          ),
         ],
       ),
     );

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -6,10 +6,8 @@ import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/benchmark/benchmark.dart';
 import 'package:mlperfbench/benchmark/state.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
-import 'package:mlperfbench/ui/error_dialog.dart';
 import 'package:mlperfbench/ui/home/app_drawer.dart';
 import 'package:mlperfbench/ui/home/benchmark_info_button.dart';
-import 'package:mlperfbench/ui/home/benchmark_running_screen.dart';
 import 'package:mlperfbench/ui/home/result_circle.dart';
 import 'package:mlperfbench/ui/home/share_button.dart';
 import 'package:mlperfbench/ui/home/shared_styles.dart';
@@ -117,32 +115,15 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       icon: const Icon(Icons.restart_alt),
       color: Colors.white,
       onPressed: () async {
-        try {
-          await state.resetBenchmarkState();
-        } catch (e, t) {
-          print(t);
-          // current context may no longer be valid if runBenchmarks requested progress screen
-          await showErrorDialog(
-              BenchmarkRunningScreen.scaffoldKey.currentContext ?? context,
-              ['${l10n.runFail}:', e.toString()]);
-          return;
-        }
+        await state.resetBenchmarkState();
       },
     );
     Widget deleteResultButton = IconButton(
       icon: const Icon(Icons.delete),
       color: Colors.white,
       onPressed: () async {
-        try {
-          print('hello world');
-        } catch (e, t) {
-          print(t);
-          // current context may no longer be valid if runBenchmarks requested progress screen
-          await showErrorDialog(
-              BenchmarkRunningScreen.scaffoldKey.currentContext ?? context,
-              ['${l10n.runFail}:', e.toString()]);
-          return;
-        }
+        await state.resourceManager.resultManager.deleteLastResult();
+        await state.resetBenchmarkState();
       },
     );
     return Container(

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -240,7 +240,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       final acceleratorName = perfResult.acceleratorName;
       backendInfo = '$backendName | $delegateName | $acceleratorName';
     }
-    var rows = <Widget>[];
+    var subtitleColumnChildren = <Widget>[];
     final resultTextStyle = TextStyle(
       color: resultIsValid ? AppColors.resultValid : AppColors.resultInvalid,
       fontSize: 18.0,
@@ -255,7 +255,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       ],
     );
     final backendInfoRow = Text(backendInfo);
-    rows.add(backendInfoRow);
+    subtitleColumnChildren.add(backendInfoRow);
 
     if (benchmark.info.isOffline) {
       String batchSize;
@@ -276,21 +276,21 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
           ),
         ],
       );
-      rows.add(batchSizeRow);
+      subtitleColumnChildren.add(batchSizeRow);
     }
 
     final progressBarRow = FractionallySizedBox(
       widthFactor: 0.9,
       child: BlueProgressLine(progressBarValue ?? 0.0),
     );
-    rows.add(progressBarRow);
+    subtitleColumnChildren.add(progressBarRow);
 
     if (progressBarValue2 != null) {
       final progressBarRow2 = FractionallySizedBox(
         widthFactor: 0.9,
         child: BlueProgressLine(progressBarValue2),
       );
-      rows.add(progressBarRow2);
+      subtitleColumnChildren.add(progressBarRow2);
     }
 
     return ListTile(
@@ -309,7 +309,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: rows,
+          children: subtitleColumnChildren,
         ),
       ),
       trailing: SizedBox(

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -239,6 +239,8 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     return Container(
       color: AppColors.appBarBackground,
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.75,
@@ -253,29 +255,6 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
             ),
           ),
           ResultCircle(state.result),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(30, 20, 30, 20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  l10n.resultsTitleDetails,
-                  textAlign: TextAlign.left,
-                  style: const TextStyle(
-                      fontSize: 17.0, fontWeight: FontWeight.bold),
-                ),
-                IconButton(
-                    key: const Key(ResultKeys.scrollResultsButton),
-                    icon: app_icons.AppIcons.arrow,
-                    onPressed: () {
-                      _scrollController.animateTo(
-                          _scrollController.position.maxScrollExtent,
-                          duration: const Duration(milliseconds: 200),
-                          curve: Curves.ease);
-                    })
-              ],
-            ),
-          ),
         ],
       ),
     );

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -12,6 +12,7 @@ import 'package:mlperfbench/ui/home/benchmark_info_button.dart';
 import 'package:mlperfbench/ui/home/benchmark_running_screen.dart';
 import 'package:mlperfbench/ui/home/result_circle.dart';
 import 'package:mlperfbench/ui/home/share_button.dart';
+import 'package:mlperfbench/ui/home/shared_styles.dart';
 
 enum _ScreenMode { performance, accuracy }
 
@@ -67,10 +68,6 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     state = context.watch<BenchmarkState>();
     l10n = AppLocalizations.of(context);
 
-    final sharingSection = _sharingSection();
-    final summarySection = _summarySection();
-    final detailSection = _detailSection();
-
     String title;
     title = _screenMode == _ScreenMode.performance
         ? l10n.resultsTitlePerformance
@@ -90,11 +87,10 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                summarySection,
+                (_sharingSection()),
+                (_summarySection()),
                 const SizedBox(height: 20),
-                detailSection,
-                const SizedBox(height: 20),
-                sharingSection,
+                (_detailSection()),
               ],
             ),
           );
@@ -104,65 +100,64 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
   }
 
   Widget _sharingSection() {
-    final minimumShareButtonWidth = MediaQuery.of(context).size.width - 40;
-    final buttonStyle = ButtonStyle(
-        backgroundColor:
-            MaterialStateProperty.all<Color>(AppColors.runBenchmarkRectangle),
-        shape: MaterialStateProperty.all(RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14.0),
-            side: const BorderSide(color: Colors.white))),
-        minimumSize:
-            MaterialStateProperty.all<Size>(Size(minimumShareButtonWidth, 0)));
-    return Column(
-      children: [
-        Padding(
-            padding: const EdgeInsets.fromLTRB(10, 10, 10, 10),
-            child: TextButton(
-              style: buttonStyle,
-              onPressed: () async {
-                try {
-                  await state.resetBenchmarkState();
-                } catch (e, t) {
-                  print(t);
-                  // current context may no longer be valid if runBenchmarks requested progress screen
-                  await showErrorDialog(
-                      BenchmarkRunningScreen.scaffoldKey.currentContext ??
-                          context,
-                      ['${l10n.runFail}:', e.toString()]);
-                  return;
-                }
-              },
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(0, 10, 0, 10),
-                child: Text(
-                  l10n.resultsButtonTestAgain,
-                  style: const TextStyle(
-                    fontSize: 20.0,
-                    color: AppColors.lightText,
-                  ),
-                ),
-              ),
-            )),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(10, 10, 10, 10),
-          child: ShareButton(),
+    Widget deviceName = Text(
+        state.lastResult?.environmentInfo.platform.toString() ??
+            'Unknown platform');
+    Widget testAgainButton = IconButton(
+      icon: const Icon(Icons.replay),
+      color: Colors.white,
+      onPressed: () async {
+        try {
+          await state.resetBenchmarkState();
+        } catch (e, t) {
+          print(t);
+          // current context may no longer be valid if runBenchmarks requested progress screen
+          await showErrorDialog(
+              BenchmarkRunningScreen.scaffoldKey.currentContext ?? context,
+              ['${l10n.runFail}:', e.toString()]);
+          return;
+        }
+      },
+    );
+    Widget deleteResultButton = IconButton(
+      icon: const Icon(Icons.delete),
+      color: Colors.white,
+      onPressed: () async {
+        try {
+          print('hello world');
+        } catch (e, t) {
+          print(t);
+          // current context may no longer be valid if runBenchmarks requested progress screen
+          await showErrorDialog(
+              BenchmarkRunningScreen.scaffoldKey.currentContext ?? context,
+              ['${l10n.runFail}:', e.toString()]);
+          return;
+        }
+      },
+    );
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 0, 10, 0),
+      color: AppColors.lightBlue,
+      child: DefaultTextStyle.merge(
+        style: const TextStyle(color: Colors.white),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            deviceName,
+            const Spacer(),
+            testAgainButton,
+            deleteResultButton,
+            const ShareButton()
+          ],
         ),
-      ],
+      ),
     );
   }
 
   Widget _summarySection() {
     return Container(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            AppColors.lightBlue,
-            AppColors.darkBlue,
-          ],
-        ),
-      ),
+      decoration: mainLinearGradientDecoration,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         crossAxisAlignment: CrossAxisAlignment.center,

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -73,7 +73,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       appBar: AppBar(
         title: Text(title),
         bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(60.0),
+          preferredSize: const Size.fromHeight(56.0),
           child: _sharingSection(),
         ),
       ),
@@ -141,7 +141,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       },
     );
     return Container(
-      padding: const EdgeInsets.fromLTRB(20, 10, 10, 10),
+      padding: const EdgeInsets.fromLTRB(20, 8, 10, 8),
       color: AppColors.mediumBlue,
       child: DefaultTextStyle.merge(
         style: const TextStyle(color: Colors.white),
@@ -294,7 +294,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     }
 
     return ListTile(
-      contentPadding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
+      contentPadding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
       minVerticalPadding: 0,
       leading: SizedBox(
           width: leadingWidth,
@@ -315,11 +315,19 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       trailing: SizedBox(
         width: trailingWidth,
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          mainAxisAlignment: MainAxisAlignment.end,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            ClipRect(child: benchmarkScore),
-            BenchmarkInfoButton(benchmark: benchmark),
+            Flexible(
+              flex: 7,
+              fit: FlexFit.tight,
+              child: benchmarkScore,
+            ),
+            Flexible(
+              flex: 3,
+              fit: FlexFit.tight,
+              child: BenchmarkInfoButton(benchmark: benchmark),
+            ),
           ],
         ),
       ),

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -13,6 +13,7 @@ import 'package:mlperfbench/ui/home/benchmark_running_screen.dart';
 import 'package:mlperfbench/ui/home/result_circle.dart';
 import 'package:mlperfbench/ui/home/share_button.dart';
 import 'package:mlperfbench/ui/home/shared_styles.dart';
+import 'package:mlperfbench/ui/time_utils.dart';
 
 enum _ScreenMode { performance, accuracy }
 
@@ -100,9 +101,18 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
   }
 
   Widget _sharingSection() {
-    Widget deviceName = Text(
-        state.lastResult?.environmentInfo.platform.toString() ??
-            'Unknown platform');
+    final lastResult = state.lastResult;
+    Widget infoSection = Container();
+    if (lastResult != null) {
+      infoSection = Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(lastResult.environmentInfo.modelDescription),
+          Text(formatDateTime(lastResult.meta.creationDate)),
+        ],
+      );
+    }
     Widget testAgainButton = IconButton(
       icon: const Icon(Icons.replay),
       color: Colors.white,
@@ -137,14 +147,14 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     );
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 0, 10, 0),
-      color: AppColors.lightBlue,
+      color: AppColors.mediumBlue,
       child: DefaultTextStyle.merge(
         style: const TextStyle(color: Colors.white),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            deviceName,
+            infoSection,
             const Spacer(),
             testAgainButton,
             deleteResultButton,

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -241,6 +241,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       backendInfo = '$backendName | $delegateName | $acceleratorName';
     }
     var subtitleColumnChildren = <Widget>[];
+    subtitleColumnChildren.add(const SizedBox(height: 4));
     final resultTextStyle = TextStyle(
       color: resultIsValid ? AppColors.resultValid : AppColors.resultInvalid,
       fontSize: 18.0,
@@ -256,6 +257,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     );
     final backendInfoRow = Text(backendInfo);
     subtitleColumnChildren.add(backendInfoRow);
+    subtitleColumnChildren.add(const SizedBox(height: 8));
 
     if (benchmark.info.isOffline) {
       String batchSize;
@@ -277,6 +279,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
         ],
       );
       subtitleColumnChildren.add(batchSizeRow);
+      subtitleColumnChildren.add(const SizedBox(height: 8));
     }
 
     final progressBarRow = FractionallySizedBox(

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -13,11 +13,6 @@ import 'package:mlperfbench/ui/home/benchmark_config_screen.dart';
 import 'package:mlperfbench/ui/home/shared_styles.dart';
 import 'package:mlperfbench/ui/icons.dart';
 
-class MainKeys {
-  // list of widget keys that need to be accessed in the test code
-  static const String goButton = 'goButton';
-}
-
 class BenchmarkStartScreen extends StatelessWidget {
   const BenchmarkStartScreen({Key? key}) : super(key: key);
 
@@ -131,7 +126,7 @@ class BenchmarkStartScreen extends StatelessWidget {
         Container(
           alignment: Alignment.center,
           child: ElevatedButton(
-            key: const Key(MainKeys.goButton),
+            key: const Key(WidgetKeys.goButton),
             style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.green,
                 shape: const CircleBorder(),

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -29,7 +29,7 @@ class BenchmarkStartScreen extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(
-      backgroundColor: AppColors.darBlue,
+      backgroundColor: AppColors.darkBlue,
       appBar: AppBar(title: Text(l10n.menuHome)),
       drawer: const AppDrawer(),
       body: SafeArea(

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -171,6 +171,16 @@ class BenchmarkStartScreen extends StatelessWidget {
                   }
                 }
               }
+              final selectedCount =
+                  state.benchmarks.where((e) => e.isActive).length;
+              if (selectedCount < 1) {
+                // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
+                // ignore: use_build_context_synchronously
+                if (!context.mounted) return;
+                await showErrorDialog(
+                    context, [l10n.dialogContentNoSelectedBenchmarkError]);
+                return;
+              }
               try {
                 await state.runBenchmarks();
               } catch (e, t) {

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -1,6 +1,3 @@
-import 'dart:math';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
@@ -13,6 +10,7 @@ import 'package:mlperfbench/ui/confirm_dialog.dart';
 import 'package:mlperfbench/ui/error_dialog.dart';
 import 'package:mlperfbench/ui/home/app_drawer.dart';
 import 'package:mlperfbench/ui/home/benchmark_config_screen.dart';
+import 'package:mlperfbench/ui/home/shared_styles.dart';
 import 'package:mlperfbench/ui/icons.dart';
 
 class MainKeys {
@@ -35,10 +33,11 @@ class BenchmarkStartScreen extends StatelessWidget {
       body: SafeArea(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
             Expanded(
               flex: 35,
-              child: _getContainer(context, state.state),
+              child: _getTopContainer(context, state.state),
             ),
             Expanded(
               flex: 65,
@@ -56,7 +55,7 @@ class BenchmarkStartScreen extends StatelessWidget {
     );
   }
 
-  Widget _getContainer(BuildContext context, BenchmarkStateEnum state) {
+  Widget _getTopContainer(BuildContext context, BenchmarkStateEnum state) {
     if (state == BenchmarkStateEnum.aborting) {
       return _waitContainer(context);
     } else if (state == BenchmarkStateEnum.waiting) {
@@ -68,160 +67,125 @@ class BenchmarkStartScreen extends StatelessWidget {
 
   Widget _waitContainer(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final circleWidth =
+        MediaQuery.of(context).size.width * WidgetSizes.circleWidthFactor;
 
-    return _circleContainerWithContent(
-        context, AppIcons.waiting, l10n.mainScreenWaitFinish);
+    return Stack(
+      alignment: Alignment.topCenter,
+      children: [
+        Container(
+          width: MediaQuery.of(context).size.width,
+          alignment: Alignment.center,
+          decoration: mainLinearGradientDecoration,
+        ),
+        Padding(
+          padding: const EdgeInsets.all(20),
+          child: Text(
+            l10n.mainScreenWaitFinish,
+            style: const TextStyle(color: AppColors.lightText, fontSize: 15),
+          ),
+        ),
+        Stack(
+          children: [
+            Container(
+              width: circleWidth,
+              alignment: Alignment.center,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.progressCircle,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black12,
+                    offset: Offset(15, 15),
+                    blurRadius: 10,
+                  )
+                ],
+              ),
+            ),
+            Container(
+              width: circleWidth,
+              alignment: Alignment.center,
+              child: AppIcons.waiting,
+            )
+          ],
+        )
+      ],
+    );
   }
 
   Widget _goContainer(BuildContext context) {
     final state = context.watch<BenchmarkState>();
     final store = context.watch<Store>();
     final l10n = AppLocalizations.of(context);
+    final circleWidth =
+        MediaQuery.of(context).size.width * WidgetSizes.circleWidthFactor;
 
-    return CustomPaint(
-      painter: MyPaintBottom(),
-      child: GoButtonGradient(() async {
-        final wrongPathError = await state.validator
-            .validateExternalResourcesDirectory(l10n.dialogContentMissingFiles);
-        if (wrongPathError.isNotEmpty) {
-          // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
-          // ignore: use_build_context_synchronously
-          if (!context.mounted) return;
-          await showErrorDialog(context, [wrongPathError]);
-          return;
-        }
-        if (store.offlineMode) {
-          final offlineError = await state.validator
-              .validateOfflineMode(l10n.dialogContentOfflineWarning);
-          if (offlineError.isNotEmpty) {
-            // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
-            // ignore: use_build_context_synchronously
-            if (!context.mounted) return;
-            switch (await showConfirmDialog(context, offlineError)) {
-              case ConfirmDialogAction.ok:
-                break;
-              case ConfirmDialogAction.cancel:
+    return Stack(
+      alignment: Alignment.topCenter,
+      children: [
+        Container(
+          width: MediaQuery.of(context).size.width,
+          alignment: Alignment.center,
+          decoration: mainLinearGradientDecoration,
+        ),
+        Container(
+          alignment: Alignment.center,
+          child: ElevatedButton(
+            key: const Key(MainKeys.goButton),
+            style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.green,
+                shape: const CircleBorder(),
+                minimumSize: Size.fromWidth(circleWidth)),
+            child: Text(
+              l10n.mainScreenGo,
+              style: const TextStyle(
+                color: AppColors.lightText,
+                fontSize: 40,
+              ),
+            ),
+            onPressed: () async {
+              final wrongPathError = await state.validator
+                  .validateExternalResourcesDirectory(
+                      l10n.dialogContentMissingFiles);
+              if (wrongPathError.isNotEmpty) {
+                // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
+                // ignore: use_build_context_synchronously
+                if (!context.mounted) return;
+                await showErrorDialog(context, [wrongPathError]);
                 return;
-              default:
-                break;
-            }
-          }
-        }
-        try {
-          await state.runBenchmarks();
-        } catch (e, t) {
-          print(t);
-          // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
-          // ignore: use_build_context_synchronously
-          if (!context.mounted) return;
-          await showErrorDialog(context, ['${l10n.runFail}:', e.toString()]);
-          return;
-        }
-      }),
-    );
-  }
-}
-
-class MyPaintBottom extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final rect =
-        Rect.fromCircle(center: Offset(size.width / 2, 0), radius: size.height);
-    final paint = Paint()
-      ..shader = LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomLeft,
-        colors: AppColors.mainScreenGradient,
-      ).createShader(rect);
-    canvas.drawArc(rect, 0, pi, true, paint);
-  } // paint
-
-  @override
-  bool shouldRepaint(MyPaintBottom oldDelegate) => false;
-}
-
-class GoButtonGradient extends StatelessWidget {
-  final AsyncCallback onPressed;
-
-  const GoButtonGradient(this.onPressed, {Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-
-    var decoration = BoxDecoration(
-      shape: BoxShape.circle,
-      gradient: LinearGradient(
-        colors: AppColors.runBenchmarkCircleGradient,
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-      ),
-      boxShadow: const [
-        BoxShadow(
-          color: Colors.black12,
-          offset: Offset(15, 15),
-          blurRadius: 10,
-        )
+              }
+              if (store.offlineMode) {
+                final offlineError = await state.validator
+                    .validateOfflineMode(l10n.dialogContentOfflineWarning);
+                if (offlineError.isNotEmpty) {
+                  // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
+                  // ignore: use_build_context_synchronously
+                  if (!context.mounted) return;
+                  switch (await showConfirmDialog(context, offlineError)) {
+                    case ConfirmDialogAction.ok:
+                      break;
+                    case ConfirmDialogAction.cancel:
+                      return;
+                    default:
+                      break;
+                  }
+                }
+              }
+              try {
+                await state.runBenchmarks();
+              } catch (e, t) {
+                print(t);
+                // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
+                // ignore: use_build_context_synchronously
+                if (!context.mounted) return;
+                await showErrorDialog(
+                    context, ['${l10n.runFail}:', e.toString()]);
+                return;
+              }
+            },
+          ),
+        ),
       ],
     );
-
-    return Container(
-      decoration: decoration,
-      width: MediaQuery.of(context).size.width * 0.32,
-      child: MaterialButton(
-        key: const Key(MainKeys.goButton),
-        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        splashColor: Colors.black,
-        shape: const CircleBorder(),
-        onPressed: onPressed,
-        child: Text(
-          l10n.mainScreenGo,
-          style: const TextStyle(
-            color: AppColors.lightText,
-            fontSize: 40,
-          ),
-        ),
-      ),
-    );
   }
-}
-
-Widget _circleContainerWithContent(
-    BuildContext context, Widget contentInCircle, String label) {
-  return CustomPaint(
-    painter: MyPaintBottom(),
-    child: Stack(alignment: Alignment.topCenter, children: [
-      Padding(
-        padding: const EdgeInsets.all(20),
-        child: Text(
-          label,
-          style: const TextStyle(color: AppColors.lightText, fontSize: 15),
-        ),
-      ),
-      Stack(
-        children: [
-          Container(
-            width: MediaQuery.of(context).size.width * 0.35,
-            alignment: Alignment.center,
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color: AppColors.progressCircle,
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black12,
-                  offset: Offset(15, 15),
-                  blurRadius: 10,
-                )
-              ],
-            ),
-          ),
-          Container(
-            width: MediaQuery.of(context).size.width * 0.35,
-            alignment: Alignment.center,
-            child: contentInCircle,
-          )
-        ],
-      )
-    ]),
-  );
 }

--- a/flutter/lib/ui/home/share_button.dart
+++ b/flutter/lib/ui/home/share_button.dart
@@ -11,14 +11,34 @@ import 'package:mlperfbench/ui/home/user_profile.dart';
 
 enum _ShareDestination { local, cloud }
 
-class ShareButton extends StatefulWidget {
+class ShareButton extends StatelessWidget {
   const ShareButton({Key? key}) : super(key: key);
 
   @override
-  State<ShareButton> createState() => _ShareButton();
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.share),
+      color: Colors.white,
+      onPressed: () {
+        showModalBottomSheet(
+          context: context,
+          builder: (_) => Wrap(
+            children: const [ShareBottomSheet()],
+          ),
+        );
+      },
+    );
+  }
 }
 
-class _ShareButton extends State<ShareButton> {
+class ShareBottomSheet extends StatefulWidget {
+  const ShareBottomSheet({Key? key}) : super(key: key);
+
+  @override
+  State<ShareBottomSheet> createState() => _ShareButton();
+}
+
+class _ShareButton extends State<ShareBottomSheet> {
   late BenchmarkState state;
   late AppLocalizations l10n;
   bool _isSharing = false;
@@ -29,16 +49,7 @@ class _ShareButton extends State<ShareButton> {
     state = context.watch<BenchmarkState>();
     l10n = AppLocalizations.of(context);
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          _buildShareButton(context),
-          const SizedBox(height: 16.0),
-          _isSharing ? _buildProgressIndicator() : Container(),
-          const SizedBox(height: 16.0),
-          Text(_shareStatus),
-        ],
-      ),
+      child: _buildShareModal(context),
     );
   }
 
@@ -67,74 +78,61 @@ class _ShareButton extends State<ShareButton> {
     }
   }
 
-  Widget _buildShareButton(BuildContext context) {
-    return TextButton(
-      onPressed: () {
-        showModalBottomSheet(
-          context: context,
-          builder: (context) {
-            return Padding(
-              padding: const EdgeInsets.fromLTRB(16, 20, 16, 40),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  TextButton(
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                      _handleSharing(_ShareDestination.local);
-                    },
-                    child: Row(
-                      children: [
-                        const Icon(Icons.share),
-                        const SizedBox(width: 20),
-                        Text(
-                          l10n.shareButtonOther,
-                          style: TextStyle(
-                            color: AppColors.shareTextButton,
-                            fontSize: 18,
-                          ),
-                        ),
-                      ],
-                    ),
+  Padding _buildShareModal(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 10),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          TextButton(
+            onPressed: () {
+              _handleSharing(_ShareDestination.local);
+            },
+            child: Row(
+              children: [
+                const Icon(Icons.share),
+                const SizedBox(width: 20),
+                Text(
+                  l10n.shareButtonOther,
+                  style: TextStyle(
+                    color: AppColors.shareTextButton,
+                    fontSize: 18,
                   ),
-                  TextButton(
-                    onPressed: () {
-                      if (!FirebaseManager.enabled) {
-                        return;
-                      }
-                      if (!FirebaseManager.instance.isSignedIn) {
-                        _buildProfileModal(context);
-                        return;
-                      }
-                      Navigator.of(context).pop();
-                      _handleSharing(_ShareDestination.cloud);
-                    },
-                    child: Row(
-                      children: [
-                        const Icon(Icons.cloud_upload),
-                        const SizedBox(width: 20),
-                        Text(
-                          l10n.shareButtonMLCommons,
-                          style: TextStyle(
-                            color: AppColors.shareTextButton,
-                            fontSize: 18,
-                          ),
-                        ),
-                      ],
-                    ),
+                ),
+              ],
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              if (!FirebaseManager.enabled) {
+                return;
+              }
+              if (!FirebaseManager.instance.isSignedIn) {
+                _buildProfileModal(context);
+                return;
+              }
+              _handleSharing(_ShareDestination.cloud);
+            },
+            child: Row(
+              children: [
+                const Icon(Icons.cloud_upload),
+                const SizedBox(width: 20),
+                Text(
+                  l10n.shareButtonMLCommons,
+                  style: TextStyle(
+                    color: AppColors.shareTextButton,
+                    fontSize: 18,
                   ),
-                ],
-              ),
-            );
-          },
-        );
-      },
-      child: Text(
-        l10n.resultsButtonShare,
-        style: TextStyle(
-          color: AppColors.shareTextButton,
-          fontSize: 18,
-        ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            height: 40,
+            child: _isSharing ? _buildProgressIndicator() : Text(_shareStatus),
+          ),
+        ],
       ),
     );
   }

--- a/flutter/lib/ui/home/shared_styles.dart
+++ b/flutter/lib/ui/home/shared_styles.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+import 'package:mlperfbench/app_constants.dart';
+
+const mainLinearGradientDecoration = BoxDecoration(
+  gradient: LinearGradient(
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+    colors: [
+      AppColors.lightBlue,
+      AppColors.darkBlue,
+    ],
+  ),
+);

--- a/flutter/unit_test/data/result_filter_test.dart
+++ b/flutter/unit_test/data/result_filter_test.dart
@@ -122,5 +122,12 @@ void main() {
       final filter = ResultFilter();
       expect(filter.anyFilterActive, isFalse);
     });
+
+    test('empty result list', () {
+      final filter = ResultFilter();
+      final emptyResult = ExtendedResult.fromJson(data);
+      emptyResult.results.clear();
+      expect(filter.match(emptyResult), isFalse);
+    });
   });
 }


### PR DESCRIPTION
- Part of https://github.com/mlcommons/mobile_app_open/issues/806
- New design for result screen

<img src="https://github.com/mlcommons/mobile_app_open/assets/85728587/76f1fbcb-d5d5-4677-bbef-cd4473a5c7df" width="320">

<img src="https://github.com/mlcommons/mobile_app_open/assets/85728587/4ed1309b-8a95-4a78-9032-fe2cc452cc6e" width="320">


<img width="1400" alt="result" src="https://github.com/mlcommons/mobile_app_open/assets/85728587/85f1228b-18fc-48f9-b49c-cbddf9aa7af6">
