### PR TITLE
ci: replace obsolete Windows image

### DIFF
--- a/.github/cloudbuild/flutter-windows.yaml
+++ b/.github/cloudbuild/flutter-windows.yaml
@@ -34,7 +34,7 @@ steps:
       - --region=$_CE_REGION
       - --zone=$_CE_ZONE
       - --machineType=$_CE_MACHINE_TYPE
-      - --image=projects/gce-uefi-images/global/images/windows-server-2019-dc-for-containers-v20200609
+      - --image=projects/gce-uefi-images/global/images/windows-server-2019-dc-for-containers-v20200512
       # When using other disk types image pulling and image building could take up to 3 hours
       - --diskType=pd-ssd
       - --workspace-bucket=$_WORKSPACE_TMP_BUCKET


### PR DESCRIPTION
The old Windows image is not available anymore on Google Cloud and therefore be replaced with another one.