### PR TITLE
chore: increase Android targetSdkVersion from 33 to 34

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -223,6 +223,13 @@ jobs:
           path: output/android-apks/*-qsmgt-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
+      - name: Archive AAB with unified backend
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab-unified-${{ github.run_number }}
+          path: output/android-apks/*-qsmgt-${{ github.run_number }}.aab
+          retention-days: 28
+          if-no-files-found: error
 
   test-android-apk-tflite:
     needs: build-android-apk

--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -47,6 +47,10 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        ndk {
+          abiFilters "arm64-v8a", "armeabi-v7a"
+        }
     }
 
     signingConfigs {

--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         applicationId "org.mlcommons.android.mlperfbench"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
From Play Store:
> Violation: 
App must target Android 14 (API level 34) or higher.

> Details: 
To provide users with a safe and secure experience, Google Play requires all apps to meet target API level requirements.
From Aug 31, 2024, if your target API level is not within 1 year of the latest Android release, you won't be able to update your app.