### PR TITLE
feat: add support for multiple model files

### DIFF
--- a/flutter/cpp/proto/backend_setting.proto
+++ b/flutter/cpp/proto/backend_setting.proto
@@ -51,7 +51,7 @@ message BenchmarkSetting {
 }
 
 // Config of a delegate.
-// Next ID: 8
+// Next ID: 10
 message DelegateSetting {
   // Priority of the delegate. Used for sorting delegate choices in frontend.
   optional int32 priority = 1 [default = 0];
@@ -61,10 +61,8 @@ message DelegateSetting {
   required string accelerator_name = 3;
   // Human-readable name of the accelerator (hardware)
   required string accelerator_desc = 4;
-  // URL or local path of the model file
-  required string model_path = 5;
-  // MD5 checksum to validate the model file
-  required string model_checksum = 6;
+  // The model file to be used when using this delegate
+  repeated ModelFile model_file = 9;
   // The batch size to be used when running the model. Default to 1.
   optional int32 batch_size = 7 [default = 1];
   // Custom setting for this delegate.
@@ -109,4 +107,12 @@ message CustomSetting {
 message SettingList {
   repeated CommonSetting setting = 1;
   optional BenchmarkSetting benchmark_setting = 2;
+}
+
+// ModelFile will downloaded by the app and passed to the vendor backend
+message ModelFile {
+  // URL or local path of the model file
+  required string model_path = 5;
+  // MD5 checksum to validate the model file
+  required string model_checksum = 6;
 }

--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -36,10 +36,12 @@ Future<void> validateSettings(WidgetTester tester) async {
   for (var benchmark in benchmarkState.benchmarks) {
     expect(benchmark.selectedDelegate.batchSize, greaterThanOrEqualTo(0),
         reason: 'batchSize must >= 0');
-    expect(benchmark.selectedDelegate.modelPath.isNotEmpty, isTrue,
-        reason: 'modelPath cannot be empty');
-    expect(benchmark.selectedDelegate.modelChecksum.isNotEmpty, isTrue,
-        reason: 'modelChecksum cannot be empty');
+    for (var modelFile in benchmark.selectedDelegate.modelFile) {
+      expect(modelFile.modelPath.isNotEmpty, isTrue,
+          reason: 'modelPath cannot be empty');
+      expect(modelFile.modelChecksum.isNotEmpty, isTrue,
+          reason: 'modelChecksum cannot be empty');
+    }
     expect(benchmark.selectedDelegate.acceleratorName.isNotEmpty, isTrue,
         reason: 'acceleratorName cannot be empty');
     expect(benchmark.selectedDelegate.acceleratorDesc.isNotEmpty, isTrue,

--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -92,9 +92,11 @@ class Benchmark {
       setting: commonSettings,
       benchmarkSetting: benchmarkSettings,
     );
-
+    // TODO: put multiple model files into one directory and pass them to backend
+    final backendModelPath =
+        resourceManager.get(selectedDelegate.modelFile.first.modelPath);
     return RunSettings(
-      backend_model_path: resourceManager.get(selectedDelegate.modelPath),
+      backend_model_path: backendModelPath,
       backend_lib_name: backendLibName,
       backend_settings: settings,
       backend_native_lib_path: DeviceInfo.instance.nativeLibraryPath,
@@ -167,12 +169,14 @@ class BenchmarkStore {
       }
 
       for (final delegate in b.benchmarkSettings.delegateChoice) {
-        final model = Resource(
-          path: delegate.modelPath,
-          type: ResourceTypeEnum.model,
-          md5Checksum: delegate.modelChecksum,
-        );
-        result.add(model);
+        for (final modelFile in delegate.modelFile) {
+          final model = Resource(
+            path: modelFile.modelPath,
+            type: ResourceTypeEnum.model,
+            md5Checksum: modelFile.modelChecksum,
+          );
+          result.add(model);
+        }
       }
     }
 

--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -63,7 +63,7 @@ class Benchmark {
     return delegate;
   }
 
-  RunSettings createRunSettings({
+  Future<RunSettings> createRunSettings({
     required BenchmarkRunMode runMode,
     required ResourceManager resourceManager,
     required List<pb.CommonSetting> commonSettings,
@@ -71,7 +71,7 @@ class Benchmark {
     required String logDir,
     required int testMinDuration,
     required int testMinQueryCount,
-  }) {
+  }) async {
     final dataset = runMode.chooseDataset(taskConfig);
 
     int minQueryCount;
@@ -92,9 +92,10 @@ class Benchmark {
       setting: commonSettings,
       benchmarkSetting: benchmarkSettings,
     );
-    // TODO: put multiple model files into one directory and pass them to backend
+    final uris = selectedDelegate.modelFile.map((e) => e.modelPath).toList();
+    final modelDirName = selectedDelegate.delegateName.replaceAll(' ', '_');
     final backendModelPath =
-        resourceManager.get(selectedDelegate.modelFile.first.modelPath);
+        await resourceManager.getModelPath(uris, modelDirName);
     return RunSettings(
       backend_model_path: backendModelPath,
       backend_lib_name: backendLibName,

--- a/flutter/lib/resources/export_result_helper.dart
+++ b/flutter/lib/resources/export_result_helper.dart
@@ -88,12 +88,15 @@ class ResultHelper {
     final delegate = benchmark.selectedDelegate;
     final extraSettings = _extraSettingsFromCommon(commonSettings) +
         _extraSettingsFromCustom(benchmark.selectedDelegate.customSetting);
+    final modelPathsJoined =
+        delegate.modelFile.map((e) => e.modelPath).join(', ');
+    final modelPathString = '[$modelPathsJoined]';
     return BackendSettingsInfo(
       acceleratorCode: delegate.acceleratorName,
       acceleratorDesc: delegate.acceleratorDesc,
       delegate: delegate.delegateName,
       framework: benchmark.benchmarkSettings.framework,
-      modelPath: delegate.modelPath,
+      modelPath: modelPathString,
       batchSize: delegate.batchSize,
       extraSettings: extraSettings,
     );

--- a/flutter/lib/resources/file_cache_helper.dart
+++ b/flutter/lib/resources/file_cache_helper.dart
@@ -46,7 +46,7 @@ class FileCacheHelper {
   Future<File> _download(String url) async {
     print('downloading $url');
     const successStatusCode = 200;
-
+    _httpClient.idleTimeout = const Duration(seconds: 60);
     final response = await _httpClient
         .getUrl(Uri.parse(url))
         .then((request) => request.close());

--- a/flutter/unit_test/benchmark/benchmark_store_test.dart
+++ b/flutter/unit_test/benchmark/benchmark_store_test.dart
@@ -19,9 +19,12 @@ void main() {
         tiny: pb.OneDatasetConfig(inputPath: 'tiny-inputPath'),
       ),
     );
+    final model1 = pb.ModelFile(
+      modelPath: 'model1-path',
+    );
     final choice1 = pb.DelegateSetting(
       delegateName: 'delegate1',
-      modelPath: 'model1-path',
+      modelFile: [model1],
     );
     final backendSettings1 = pb.BenchmarkSetting(
       benchmarkId: 'task1',
@@ -115,7 +118,8 @@ void main() {
       expect(
           resources,
           contains(Resource(
-            path: backendSettings1.delegateChoice.first.modelPath,
+            path:
+                backendSettings1.delegateChoice.first.modelFile.first.modelPath,
             type: ResourceTypeEnum.model,
             md5Checksum: '',
           )));
@@ -140,7 +144,8 @@ void main() {
       expect(
           resources,
           contains(Resource(
-            path: backendSettings1.delegateChoice.first.modelPath,
+            path:
+                backendSettings1.delegateChoice.first.modelFile.first.modelPath,
             type: ResourceTypeEnum.model,
             md5Checksum: '',
           )));
@@ -168,7 +173,8 @@ void main() {
       expect(
           resources,
           contains(Resource(
-            path: backendSettings1.delegateChoice.first.modelPath,
+            path:
+                backendSettings1.delegateChoice.first.modelFile.first.modelPath,
             type: ResourceTypeEnum.model,
             md5Checksum: '',
           )));

--- a/mobile_back_apple/cpp/backend_coreml/coreml_settings.pbtxt
+++ b/mobile_back_apple/cpp/backend_coreml/coreml_settings.pbtxt
@@ -8,22 +8,28 @@ benchmark_setting {
     delegate_name: "CPU & GPU & ANE"
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
-    model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
+      model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
-    model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
+      model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    }
   }
    delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
-    model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
+      model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -36,24 +42,30 @@ benchmark_setting {
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
     batch_size: 32
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
-    model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
+      model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
     batch_size: 32
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
-    model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
+      model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    }
   }
    delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
     batch_size: 32
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
-    model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobilenetEdgeTPU.mlmodel"
+      model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -65,22 +77,28 @@ benchmark_setting {
     delegate_name: "CPU & GPU & ANE"
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
-    model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
+      model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
-    model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
+      model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
-    model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
+      model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -93,24 +111,30 @@ benchmark_setting {
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
     batch_size: 32
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
-    model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
+      model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
     batch_size: 32
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
-    model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
+      model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
     batch_size: 32
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
-    model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
+      model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -122,22 +146,28 @@ benchmark_setting {
     delegate_name: "CPU & GPU & ANE"
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileDet.mlmodel"
-    model_checksum: "ef849fbf2132e205158f05ca42db25f4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileDet.mlmodel"
+      model_checksum: "ef849fbf2132e205158f05ca42db25f4"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileDet.mlmodel"
-    model_checksum: "ef849fbf2132e205158f05ca42db25f4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileDet.mlmodel"
+      model_checksum: "ef849fbf2132e205158f05ca42db25f4"
+    }
   }
    delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileDet.mlmodel"
-    model_checksum: "ef849fbf2132e205158f05ca42db25f4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileDet.mlmodel"
+      model_checksum: "ef849fbf2132e205158f05ca42db25f4"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -149,15 +179,19 @@ benchmark_setting {
     delegate_name: "CPU & GPU & ANE"
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileBERT.mlmodel"
-    model_checksum: "c7d544b5b3bd6cd9df7ebe8f04ecb7f9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileBERT.mlmodel"
+      model_checksum: "c7d544b5b3bd6cd9df7ebe8f04ecb7f9"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileBERT.mlmodel"
-    model_checksum: "c7d544b5b3bd6cd9df7ebe8f04ecb7f9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/MobileBERT.mlmodel"
+      model_checksum: "c7d544b5b3bd6cd9df7ebe8f04ecb7f9"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -169,22 +203,28 @@ benchmark_setting {
     delegate_name: "CPU & GPU & ANE"
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/Mosaic.mlmodel"
-    model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/Mosaic.mlmodel"
+      model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/Mosaic.mlmodel"
-    model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/Mosaic.mlmodel"
+      model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
+    }
   }
    delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/Mosaic.mlmodel"
-    model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/Mosaic.mlmodel"
+      model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }
@@ -196,22 +236,28 @@ benchmark_setting {
     delegate_name: "CPU & GPU & ANE"
     accelerator_name: "cpu&gpu&ane"
     accelerator_desc: "All compute units"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/edsr_f32b5_fp32.mlmodel"
-    model_checksum: "62489706f20b0c2ae561fb2204eefb61"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/edsr_f32b5_fp32.mlmodel"
+      model_checksum: "62489706f20b0c2ae561fb2204eefb61"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
     accelerator_name: "cpu&gpu"
     accelerator_desc: "CPU and GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/edsr_f32b5_fp32.mlmodel"
-    model_checksum: "62489706f20b0c2ae561fb2204eefb61"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/edsr_f32b5_fp32.mlmodel"
+      model_checksum: "62489706f20b0c2ae561fb2204eefb61"
+    }
   }
    delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/edsr_f32b5_fp32.mlmodel"
-    model_checksum: "62489706f20b0c2ae561fb2204eefb61"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/CoreML/edsr_f32b5_fp32.mlmodel"
+      model_checksum: "62489706f20b0c2ae561fb2204eefb61"
+    }
   }
   delegate_selected: "CPU & GPU & ANE"
 }

--- a/mobile_back_pixel/cpp/backend_tflite/settings/tflite_settings_pixel6.pbtxt
+++ b/mobile_back_pixel/cpp/backend_tflite/settings/tflite_settings_pixel6.pbtxt
@@ -17,15 +17,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -37,15 +41,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -57,16 +65,20 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
     batch_size: 64
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 2
   }
   delegate_selected: "NNAPI"
@@ -80,15 +92,19 @@ benchmark_setting {
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
     batch_size: 16
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 2
   }
   delegate_selected: "NNAPI"
@@ -101,15 +117,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
-    model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -121,15 +141,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "GPU EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
-    model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-    model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
   }
   delegate_selected: "NNAPI"
 
@@ -142,15 +166,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
-    model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_selected: "NNAPI"
 
@@ -163,15 +191,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "tpu"
     accelerator_desc: "Google EdgeTPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
-    model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_selected: "NNAPI"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_default_cpu.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_default_cpu.pbtxt
@@ -31,8 +31,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -53,8 +55,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 250000
   delegate_selected: "SNPE_CPU"
@@ -77,8 +81,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 128
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -108,8 +114,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -130,8 +138,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -156,8 +166,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -182,8 +194,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -208,8 +222,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_default_dsp.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_default_dsp.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -57,8 +59,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -84,8 +88,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -111,8 +117,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -137,8 +145,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -171,8 +181,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -201,8 +213,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -235,8 +249,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_default_gpu.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_default_gpu.pbtxt
@@ -31,16 +31,20 @@ benchmark_setting {
     delegate_name: "SNPE_GPU"
     accelerator_name: "snpe_gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_choice: {
     priority: 2
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -57,8 +61,10 @@ benchmark_setting {
     delegate_name: "SNPE_GPU"
     accelerator_name: "snpe_gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_choice: {
     priority: 2
@@ -66,8 +72,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 128
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -89,8 +97,10 @@ benchmark_setting {
     accelerator_name: "psnpe_gpu"
     accelerator_desc: "GPU"
     batch_size: 128
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_choice: {
     priority: 2
@@ -98,8 +108,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 128
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -121,8 +133,10 @@ benchmark_setting {
     accelerator_name: "psnpe_gpu"
     accelerator_desc: "GPU"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_choice: {
     priority: 2
@@ -130,8 +144,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 128
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -152,16 +168,20 @@ benchmark_setting {
     delegate_name: "SNPE_GPU"
     accelerator_name: "snpe_gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_choice: {
     priority: 2
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -186,16 +206,20 @@ benchmark_setting {
     delegate_name: "SNPE_GPU"
     accelerator_name: "snpe_gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_choice: {
     priority: 2
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -220,16 +244,20 @@ benchmark_setting {
     delegate_name: "SNPE_GPU"
     accelerator_name: "snpe_gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_choice: {
     priority: 2
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }
@@ -254,16 +282,20 @@ benchmark_setting {
     delegate_name: "SNPE_GPU"
     accelerator_name: "snpe_gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_choice: {
     priority: 2
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_GPU"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_gpufp16.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_gpufp16.pbtxt
@@ -31,8 +31,10 @@ benchmark_setting {
     delegate_name: "SNPE_GPU_FP16"
     accelerator_name: "snpe_gpu_fp16"
     accelerator_desc: "GPU_FP16"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   single_stream_expected_latency_ns: 500000
   delegate_selected: "SNPE_GPU_FP16"
@@ -50,8 +52,10 @@ benchmark_setting {
     delegate_name: "SNPE_GPU_FP16"
     accelerator_name: "snpe_gpu_fp16
     accelerator_desc: "GPU_FP16"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 500000
   delegate_selected: "SNPE_GPU_FP16"
@@ -73,8 +77,10 @@ benchmark_setting {
     accelerator_name: "psnpe_gpu_fp16"
     accelerator_desc: "GPU_FP16"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_GPU_FP16"
 }
@@ -95,8 +101,10 @@ benchmark_setting {
     accelerator_name: "psnpe_gpu_fp16"
     accelerator_desc: "GPU_FP16"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_GPU_FP16"
 }
@@ -128,9 +136,11 @@ benchmark_setting {
     delegate_name: "SNPE_GPU_FP16"
     accelerator_name: "snpe_gpu_fp16"
     accelerator_desc: "GPU_FP16"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
     }
+  }
   delegate_selected: "SNPE_GPU_FP16"
 }
 benchmark_setting {
@@ -153,8 +163,10 @@ benchmark_setting {
     delegate_name: "SNPE_GPU_FP16"
     accelerator_name: "snpe_gpu_fp16"
     accelerator_desc: "GPU_FP16"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_GPU_FP16"
 }
@@ -186,8 +198,10 @@ benchmark_setting {
     delegate_name: "SNPE_GPU_FP16"
     accelerator_name: "snpe_gpu_fp16"
     accelerator_desc: "GPU_FP16"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_GPU_FP16"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd7cxg3.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd7cxg3.pbtxt
@@ -39,8 +39,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -65,8 +67,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 250000
   delegate_selected: "SNPE_DSP"
@@ -97,8 +101,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_8.dlc"
-    model_checksum: "1e09cab7d0d381ef02cfd5ea5b85da92"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_8.dlc"
+      model_checksum: "1e09cab7d0d381ef02cfd5ea5b85da92"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -132,8 +138,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -158,8 +166,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -188,8 +198,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -218,8 +230,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -244,8 +258,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd7g1.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd7g1.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -61,8 +63,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -92,8 +96,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -127,8 +133,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -153,8 +161,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -187,8 +197,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -213,8 +225,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -243,8 +257,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd7pg2.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd7pg2.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   single_stream_expected_latency_ns: 600000
   delegate_selected: "SNPE_DSP"
@@ -62,8 +64,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 250000
   delegate_selected: "SNPE_DSP"
@@ -94,8 +98,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -129,8 +135,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -155,8 +163,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -189,8 +199,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -215,8 +227,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -245,8 +259,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8cxg3.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8cxg3.pbtxt
@@ -39,8 +39,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   single_stream_expected_latency_ns: 600000
   delegate_selected: "SNPE_DSP"
@@ -70,8 +72,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 60000
   delegate_selected: "SNPE_DSP"
@@ -102,8 +106,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_8.dlc"
-    model_checksum: "1e09cab7d0d381ef02cfd5ea5b85da92"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_8.dlc"
+      model_checksum: "1e09cab7d0d381ef02cfd5ea5b85da92"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -137,8 +143,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -163,8 +171,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -193,8 +203,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -223,8 +235,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -249,8 +263,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8g1.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8g1.pbtxt
@@ -39,8 +39,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   single_stream_expected_latency_ns: 800000
   delegate_selected: "SNPE_DSP"
@@ -66,8 +68,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 80000
   delegate_selected: "SNPE_DSP"
@@ -98,8 +102,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
-    model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
+      model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -133,8 +139,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -159,8 +167,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -193,8 +203,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -219,8 +231,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -249,8 +263,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8g2.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8g2.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_O2.dlc"
-    model_checksum: "25977982896e607bceb55340c8d76223"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_O2.dlc"
+      model_checksum: "25977982896e607bceb55340c8d76223"
+    }
   }
   single_stream_expected_latency_ns: 300000
   delegate_selected: "SNPE_DSP"
@@ -62,8 +64,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 50000
   delegate_selected: "SNPE_DSP"
@@ -94,8 +98,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4_O2.dlc"
-    model_checksum: "b836e404b3aa5ff7914fac8376643fe4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4_O2.dlc"
+      model_checksum: "b836e404b3aa5ff7914fac8376643fe4"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -129,8 +135,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -155,8 +163,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp_O2.dlc"
-    model_checksum: "5802abfad10a7fc5c5849b13943d6d44"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp_O2.dlc"
+      model_checksum: "5802abfad10a7fc5c5849b13943d6d44"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -189,8 +199,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp_O2.dlc"
-    model_checksum: "9d0dadbb6014289916a6078c4c991dd5"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp_O2.dlc"
+      model_checksum: "9d0dadbb6014289916a6078c4c991dd5"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -215,8 +227,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp_O2.dlc"
-    model_checksum: "99b39c2b9ea84ff13e00eaa82f00136b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp_O2.dlc"
+      model_checksum: "99b39c2b9ea84ff13e00eaa82f00136b"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -245,8 +259,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp_O2.dlc"
-    model_checksum: "18fa274659e14c57b4f6bedb6871c83f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp_O2.dlc"
+      model_checksum: "18fa274659e14c57b4f6bedb6871c83f"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8g3.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8g3.pbtxt
@@ -43,8 +43,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_O2.dlc"
-    model_checksum: "25977982896e607bceb55340c8d76223"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_O2.dlc"
+      model_checksum: "25977982896e607bceb55340c8d76223"
+    }
   }
   single_stream_expected_latency_ns: 250000
   delegate_selected: "SNPE_DSP"
@@ -70,8 +72,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 250000
   delegate_selected: "SNPE_DSP"
@@ -106,8 +110,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3_O2.dlc"
-    model_checksum: "aca3f4430fe98bbfe5c3a358ae9687e1"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3_O2.dlc"
+      model_checksum: "aca3f4430fe98bbfe5c3a358ae9687e1"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -141,8 +147,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12360
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -171,8 +179,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp_O2.dlc"
-    model_checksum: "5802abfad10a7fc5c5849b13943d6d44"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp_O2.dlc"
+      model_checksum: "5802abfad10a7fc5c5849b13943d6d44"
+    }
   }
   delegate_selected: "SNPE_DSP"
   single_stream_expected_latency_ns: 500000
@@ -206,8 +216,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp_O2.dlc"
-    model_checksum: "9d0dadbb6014289916a6078c4c991dd5"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp_O2.dlc"
+      model_checksum: "9d0dadbb6014289916a6078c4c991dd5"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -236,8 +248,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -270,8 +284,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp_O2.dlc"
-    model_checksum: "18fa274659e14c57b4f6bedb6871c83f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp_O2.dlc"
+      model_checksum: "18fa274659e14c57b4f6bedb6871c83f"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8pg1.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sd8pg1.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   single_stream_expected_latency_ns: 600000
   delegate_selected: "SNPE_DSP"
@@ -62,8 +64,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 600000
   delegate_selected: "SNPE_DSP"
@@ -94,8 +98,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -129,8 +135,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -155,8 +163,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -189,8 +199,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -215,8 +227,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -245,8 +259,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sdm778.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sdm778.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -61,8 +63,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -92,8 +96,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
-    model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
+      model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -127,8 +133,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -153,8 +161,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -187,8 +197,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -213,8 +225,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -243,8 +257,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sdm888.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sdm888.pbtxt
@@ -35,8 +35,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -61,8 +63,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -88,8 +92,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
-    model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
+      model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -123,8 +129,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -149,8 +157,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -183,8 +193,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -209,8 +221,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -239,8 +253,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sm4450.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sm4450.pbtxt
@@ -39,8 +39,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -65,8 +67,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -96,8 +100,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
-    model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_3.dlc"
+      model_checksum: "550f807bc7ef40f77018a64a47507d09"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -131,8 +137,10 @@ benchmark_setting {
     accelerator_name: "psnpe_cpu"
     accelerator_desc: "CPU"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -161,8 +169,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -195,8 +205,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -229,8 +241,10 @@ benchmark_setting {
       id: "cpu_int8"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }
@@ -271,8 +285,10 @@ benchmark_setting {
     delegate_name: "SNPE_CPU"
     accelerator_name: "snpe_cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_CPU"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sm7550.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sm7550.pbtxt
@@ -39,8 +39,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
-    model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp.dlc"
+      model_checksum: "cdf1fe622b309f692e05781661248a2b"
+    }
   }
   single_stream_expected_latency_ns: 500000
   delegate_selected: "SNPE_DSP"
@@ -66,8 +68,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 50000
   delegate_selected: "SNPE_DSP"
@@ -102,8 +106,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -137,8 +143,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4_O2.dlc"
-    model_checksum: "d349e3fb8a74a5037ecc3b2770dbd188"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4_O2.dlc"
+      model_checksum: "d349e3fb8a74a5037ecc3b2770dbd188"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -167,8 +175,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp_O2.dlc"
-    model_checksum: "5802abfad10a7fc5c5849b13943d6d44"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp_O2.dlc"
+      model_checksum: "5802abfad10a7fc5c5849b13943d6d44"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -201,8 +211,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -231,8 +243,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -261,8 +275,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp_O2.dlc"
-    model_checksum: "18fa274659e14c57b4f6bedb6871c83f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp_O2.dlc"
+      model_checksum: "18fa274659e14c57b4f6bedb6871c83f"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sm8635.pbtxt
+++ b/mobile_back_qti/cpp/backend_qti/settings/qti_settings_sm8635.pbtxt
@@ -39,8 +39,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_O2.dlc"
-    model_checksum: "25977982896e607bceb55340c8d76223"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_O2.dlc"
+      model_checksum: "25977982896e607bceb55340c8d76223"
+    }
   }
   single_stream_expected_latency_ns: 500000
   delegate_selected: "SNPE_DSP"
@@ -66,8 +68,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
-    model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp.dlc"
+      model_checksum: "dbab3e231e5f83aabc80d5b69e6dad32"
+    }
   }
   single_stream_expected_latency_ns: 50000
   delegate_selected: "SNPE_DSP"
@@ -102,8 +106,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
-    model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_edgetpu_224_1.0_htp_batched_4.dlc"
+      model_checksum: "6523060565b8d3f326f3f323c531fc1c"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -137,8 +143,10 @@ benchmark_setting {
     accelerator_name: "psnpe_dsp"
     accelerator_desc: "HTP"
     batch_size: 12288
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
-    model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilenet_v4_htp_batched_4.dlc"
+      model_checksum: "0de3b75022ce5c27d5902a080ec1cea0"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -167,8 +175,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
-    model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/ssd_mobiledet_qat_htp.dlc"
+      model_checksum: "c333fc135a8c474679d716fe391a9e2a"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -201,8 +211,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
-    model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobilebert_quantized_htp.dlc"
+      model_checksum: "7a641e4df84fc06a1237b7fe1b1c5b08"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -231,8 +243,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "HTP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
-    model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/mobile_mosaic_htp.dlc"
+      model_checksum: "e870526444c1e48df4f0505e530ecfdf"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }
@@ -261,8 +275,10 @@ benchmark_setting {
     delegate_name: "SNPE_DSP"
     accelerator_name: "snpe_dsp"
     accelerator_desc: "DSP"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
-    model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-snpe/snusr_htp.dlc"
+      model_checksum: "84ef0d9c2e7b710381cea962a22a0b41"
+    }
   }
   delegate_selected: "SNPE_DSP"
 }

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_1200.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_1200.pbtxt
@@ -25,8 +25,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic.nnc"
-    model_checksum: "1a84db0b3dc40a6e217b7f2c8eb2980b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic.nnc"
+      model_checksum: "1a84db0b3dc40a6e217b7f2c8eb2980b"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 900000
@@ -47,8 +49,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/od.nnc"
-    model_checksum: "5e7abcc8fa6f7c3e0bd8955a9ef1e8cb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/od.nnc"
+      model_checksum: "5e7abcc8fa6f7c3e0bd8955a9ef1e8cb"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -68,8 +72,10 @@ benchmark_setting {
       id: "o_type"
       value: "Int32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/is.nnc"
-    model_checksum: "b501ed669da753b08a151639798af37e"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/is.nnc"
+      model_checksum: "b501ed669da753b08a151639798af37e"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -90,8 +96,10 @@ benchmark_setting {
       id: "o_type"
       value: "Int32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sm_uint8.nnc"
-    model_checksum: "b02531ae19686c6574857bb18406966c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sm_uint8.nnc"
+      model_checksum: "b02531ae19686c6574857bb18406966c"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -112,8 +120,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sr.nnc"
-    model_checksum: "3fea2aa73be65efceb783364f4d7ae8d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sr.nnc"
+      model_checksum: "3fea2aa73be65efceb783364f4d7ae8d"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -135,8 +145,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic_offline.nnc"
-    model_checksum: "9fcba01bf828b5cb5b1a39b55a8a7ed9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic_offline.nnc"
+      model_checksum: "9fcba01bf828b5cb5b1a39b55a8a7ed9"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2100.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2100.pbtxt
@@ -25,8 +25,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic.nnc"
-    model_checksum: "955ef2ac3c134820eab901f3dac9f732"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic.nnc"
+      model_checksum: "955ef2ac3c134820eab901f3dac9f732"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 900000
@@ -47,8 +49,10 @@ benchmark_setting {
       id: "o_type"
       value: "Uint8"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/is.nnc"
-    model_checksum: "b501ed669da753b08a151639798af37e"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/is.nnc"
+      model_checksum: "b501ed669da753b08a151639798af37e"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -69,8 +73,10 @@ benchmark_setting {
       id: "o_type"
       value: "Uint8"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/sm_uint8.nnc"
-    model_checksum: "483eee2df253ecc135a6e8701cc0c909"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/sm_uint8.nnc"
+      model_checksum: "483eee2df253ecc135a6e8701cc0c909"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -91,8 +97,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/od.nnc"
-    model_checksum: "a3c7b5e8d6b978c05807e8926584758c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/od.nnc"
+      model_checksum: "a3c7b5e8d6b978c05807e8926584758c"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -113,8 +121,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/lu.nnc"
-    model_checksum: "215ee3b9224d15dc50b30d56fa7b7396"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/lu.nnc"
+      model_checksum: "215ee3b9224d15dc50b30d56fa7b7396"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -136,8 +146,10 @@ benchmark_setting {
       id: "o_type"
       value: "Float32"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic_offline.nncgo"
-    model_checksum: "c38acf6c66ca32c525c14ce25ead823a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/Samsung/ic_offline.nncgo"
+      model_checksum: "c38acf6c66ca32c525c14ce25ead823a"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2200.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2200.pbtxt
@@ -28,8 +28,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_single.nnc"
-    model_checksum: "a49175f3f4f37f59780995cec540dbf2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_single.nnc"
+      model_checksum: "a49175f3f4f37f59780995cec540dbf2"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 900000
@@ -62,8 +64,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/sm_uint8.nnc"
-    model_checksum: "f715f55818863f371336ad29ecba1183"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/sm_uint8.nnc"
+      model_checksum: "f715f55818863f371336ad29ecba1183"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -96,8 +100,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/od.nnc"
-    model_checksum: "6b34201b6696fa75311d0d43820e03d2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/od.nnc"
+      model_checksum: "6b34201b6696fa75311d0d43820e03d2"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -130,8 +136,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/mobile_bert_gpu.nnc"
-    model_checksum: "d98dfcc37ad33fa7081d6fbb5bc6ddd1"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/mobile_bert_gpu.nnc"
+      model_checksum: "d98dfcc37ad33fa7081d6fbb5bc6ddd1"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -169,8 +177,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_offline.nnc"
-    model_checksum: "8832370c770fa820dfde83e039e3243c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_0/Samsung/ic_offline.nnc"
+      model_checksum: "8832370c770fa820dfde83e039e3243c"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2300.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2300.pbtxt
@@ -37,8 +37,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_single_fence.nnc"
-    model_checksum: "a451da1f48b1fad01c17fb7a49e5822e"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_single_fence.nnc"
+      model_checksum: "a451da1f48b1fad01c17fb7a49e5822e"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 500000
@@ -71,8 +73,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/sm_uint8_fence.nnc"
-    model_checksum: "08fa7b354f82140a8863fed57c2d499b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/sm_uint8_fence.nnc"
+      model_checksum: "08fa7b354f82140a8863fed57c2d499b"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -105,8 +109,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/od_fence.nnc"
-    model_checksum: "8a7e1808446072545c990f3d219255c6"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/od_fence.nnc"
+      model_checksum: "8a7e1808446072545c990f3d219255c6"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -139,8 +145,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sr.nnc"
-    model_checksum: "3fea2aa73be65efceb783364f4d7ae8d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sr.nnc"
+      model_checksum: "3fea2aa73be65efceb783364f4d7ae8d"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -173,8 +181,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/mobile_bert_fence.nnc"
-    model_checksum: "5fb666b684a9bd0b68d497128b990137"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/mobile_bert_fence.nnc"
+      model_checksum: "5fb666b684a9bd0b68d497128b990137"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -212,8 +222,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_offline.nnc"
-    model_checksum: "6885f281a3d7a7ec3549d629dff8c8ac"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v2_1/Samsung/ic_offline.nnc"
+      model_checksum: "6885f281a3d7a7ec3549d629dff8c8ac"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000

--- a/mobile_back_samsung/samsung/lib/public/include/mbe_config_2400.pbtxt
+++ b/mobile_back_samsung/samsung/lib/public/include/mbe_config_2400.pbtxt
@@ -37,8 +37,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic.nnc"
-    model_checksum: "1a84db0b3dc40a6e217b7f2c8eb2980b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic.nnc"
+      model_checksum: "1a84db0b3dc40a6e217b7f2c8eb2980b"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 200000
@@ -71,8 +73,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/mnv4_large.nnc"
-    model_checksum: "4a4a6b332ebcabc1a06eca019a1d7d0c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/mnv4_large.nnc"
+      model_checksum: "4a4a6b332ebcabc1a06eca019a1d7d0c"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -105,8 +109,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sm_uint8.nnc"
-    model_checksum: "b02531ae19686c6574857bb18406966c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sm_uint8.nnc"
+      model_checksum: "b02531ae19686c6574857bb18406966c"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -139,8 +145,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/od.nnc"
-    model_checksum: "5e7abcc8fa6f7c3e0bd8955a9ef1e8cb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/od.nnc"
+      model_checksum: "5e7abcc8fa6f7c3e0bd8955a9ef1e8cb"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 450000
@@ -173,8 +181,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sr.nnc"
-    model_checksum: "3fea2aa73be65efceb783364f4d7ae8d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/sr.nnc"
+      model_checksum: "3fea2aa73be65efceb783364f4d7ae8d"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -207,8 +217,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "true"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/mobile_bert.nnc"
-    model_checksum: "59356d4fa598d2d4369ca43f2051aff2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/mobile_bert.nnc"
+      model_checksum: "59356d4fa598d2d4369ca43f2051aff2"
+    }
   }
   delegate_selected: "ENN_NPU"
   single_stream_expected_latency_ns: 1000000
@@ -246,8 +258,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic_offline.nnc"
-    model_checksum: "9fcba01bf828b5cb5b1a39b55a8a7ed9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/ic_offline.nnc"
+      model_checksum: "9fcba01bf828b5cb5b1a39b55a8a7ed9"
+    }
   }
   delegate_selected: "ENN_NPU"
 
@@ -286,8 +300,10 @@ benchmark_setting {
       id: "lazy_mode"
       value: "false"
     }
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/mnv4_large_offline.nnc"
-    model_checksum: "eec18f3bcca9d34f15ff73b73b7b0a2f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-samsung/mnv4_large_offline.nnc"
+      model_checksum: "eec18f3bcca9d34f15ff73b73b7b0a2f"
+    }
   }
   delegate_selected: "ENN_NPU"
 

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt
@@ -18,15 +18,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -38,15 +42,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -58,16 +66,20 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
     batch_size: 2
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 2
   }
   delegate_selected: "NNAPI"
@@ -80,16 +92,20 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
     batch_size: 2
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 2
   }
   delegate_selected: "NNAPI"
@@ -102,15 +118,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
-    model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -122,15 +142,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
-    model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-    model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
   }
   delegate_selected: "GPU"
 }
@@ -142,15 +166,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
-    model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_selected: "NNAPI"
 }
@@ -162,15 +190,19 @@ benchmark_setting {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
-    model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_selected: "NNAPI"
 }

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_iphone11.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_iphone11.pbtxt
@@ -9,16 +9,20 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 64
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 64
   }
   delegate_selected: "Core ML"
@@ -31,16 +35,20 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 64
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 64
   }
   delegate_selected: "Core ML"

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_iphone12.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_iphone12.pbtxt
@@ -9,16 +9,20 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 8
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 8
   }
   delegate_selected: "Core ML"
@@ -31,16 +35,20 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 8
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 8
   }
   delegate_selected: "Core ML"

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_iphoneX.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_iphoneX.pbtxt
@@ -9,16 +9,20 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 32
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
     batch_size: 32
   }
   delegate_selected: "Core ML"
@@ -31,16 +35,20 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 32
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
     batch_size: 32
   }
   delegate_selected: "Core ML"

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_main.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_apple_main.pbtxt
@@ -18,15 +18,19 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
   }
   delegate_selected: "Core ML"
 }
@@ -38,15 +42,19 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "Core ML"
 }
@@ -58,15 +66,19 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_selected: "Core ML"
 }
@@ -78,8 +90,10 @@ benchmark_setting {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-    model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
   }
   delegate_selected: "Metal"
 }
@@ -91,15 +105,19 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_selected: "Core ML"
 }
@@ -111,15 +129,19 @@ benchmark_setting {
     delegate_name: "Core ML"
     accelerator_name: "ane"
     accelerator_desc: "ANE"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_choice: {
     delegate_name: "Metal"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_selected: "Core ML"
 }

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_windows.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_windows.pbtxt
@@ -18,8 +18,10 @@ benchmark_setting {
     delegate_name: "CPU"
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -32,8 +34,10 @@ benchmark_setting {
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
     batch_size: 2
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "66bb4eba50987221608f8487ed405794"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_1/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -45,8 +49,10 @@ benchmark_setting {
     delegate_name: "CPU"
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -59,8 +65,10 @@ benchmark_setting {
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
     batch_size: 2
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -72,8 +80,10 @@ benchmark_setting {
     delegate_name: "CPU"
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -85,8 +95,10 @@ benchmark_setting {
     delegate_name: "CPU"
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-    model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -98,8 +110,10 @@ benchmark_setting {
     delegate_name: "CPU"
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_selected: "CPU"
 }
@@ -111,8 +125,10 @@ benchmark_setting {
     delegate_name: "CPU"
     accelerator_name: "cpu"
     accelerator_desc: "CPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_selected: "CPU"
 }

--- a/mobile_back_tflite/cpp/backend_tflite/neuron/backend_settings/tflite_settings_mtk.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/neuron/backend_settings/tflite_settings_mtk.pbtxt
@@ -1,3 +1,6 @@
+# proto-file: flutter/cpp/proto/backend_setting.proto
+# proto-message: BackendSetting
+
 common_setting {
   id: "num_threads"
   name: "Number of threads"
@@ -14,23 +17,29 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
     batch_size: 1
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -42,22 +51,28 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -69,23 +84,29 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
     batch_size: 256
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -97,23 +118,29 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
     batch_size: 256
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -125,22 +152,28 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron"
     accelerator_desc: "MediaTek NN accelerator + CPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
-    model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
-    model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -152,23 +185,29 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-no-ahwb"
     accelerator_desc: "MediaTek NN accelerator + VPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
-    model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
     batch_size: 1
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
-    model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-    model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -180,22 +219,28 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
-    model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
-    model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -207,22 +252,28 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron"
     accelerator_desc: "MediaTek NN accelerator + CPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
-    model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
-    model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_selected: "Neuron"
 }

--- a/mobile_back_tflite/cpp/backend_tflite/neuron/backend_settings/tflite_settings_mtk_mt6989.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/neuron/backend_settings/tflite_settings_mtk_mt6989.pbtxt
@@ -1,3 +1,6 @@
+# proto-file: flutter/cpp/proto/backend_setting.proto
+# proto-message: BackendSetting
+
 common_setting {
   id: "num_threads"
   name: "Number of threads"
@@ -14,31 +17,39 @@ benchmark_setting {
     delegate_name: "Neuron RT"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobilenet_edgetpu_224_1.0_uint8.dla"
-    model_checksum: "48a2cfa77645c5dd81ad4b83a3f31e8a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobilenet_edgetpu_224_1.0_uint8.dla"
+      model_checksum: "48a2cfa77645c5dd81ad4b83a3f31e8a"
+    }
     batch_size: 1
   }
   delegate_choice: {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
     batch_size: 1
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
   }
   delegate_selected: "Neuron RT"
   single_stream_expected_latency_ns: 500000
@@ -51,29 +62,37 @@ benchmark_setting {
     delegate_name: "Neuron RT"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/MobileNetV4-Conv-Large-int8-ptq.dla"
-    model_checksum: "07055309718ff681d8cd2c00f5e4b5db"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/MobileNetV4-Conv-Large-int8-ptq.dla"
+      model_checksum: "07055309718ff681d8cd2c00f5e4b5db"
+    }
   }
-   delegate_choice: {
+  delegate_choice: {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "Neuron RT"
 }
@@ -85,23 +104,29 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
     batch_size: 256
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
-    model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
-    model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -113,23 +138,29 @@ benchmark_setting {
     delegate_name: "Neuron"
     accelerator_name: "neuron-mdla"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
     batch_size: 256
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
-    model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mobilenetV4/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
-    model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/releases/download/model_upload/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
   }
   delegate_selected: "Neuron"
 }
@@ -141,29 +172,37 @@ benchmark_setting {
     delegate_name: "Neuron RT"
     accelerator_name: "neuron"
     accelerator_desc: "MediaTek NN accelerator + CPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobiledet_qat.dla"
-    model_checksum: "14b9572f121caa093cd8bf690fde997c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobiledet_qat.dla"
+      model_checksum: "14b9572f121caa093cd8bf690fde997c"
+    }
   }
   delegate_choice: {
     delegate_name: "Neuron"
     accelerator_name: "neuron"
     accelerator_desc: "MediaTek NN accelerator + CPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
-    model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
-    model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
-    model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v1_0/tflite/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
   }
   delegate_selected: "Neuron RT"
   single_stream_expected_latency_ns: 500000
@@ -176,31 +215,39 @@ benchmark_setting {
     delegate_name: "Neuron RT"
     accelerator_name: "neuron-no-ahwb"
     accelerator_desc: "MediaTek NN accelerator + VPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobilebert_int8_384_nnapi.dla"
-    model_checksum: "8c6ce45cc49bbf8bb26609bfb219164a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobilebert_int8_384_nnapi.dla"
+      model_checksum: "8c6ce45cc49bbf8bb26609bfb219164a"
+    }
     batch_size: 1
   }
   delegate_choice: {
     delegate_name: "Neuron"
     accelerator_name: "neuron-no-ahwb"
     accelerator_desc: "MediaTek NN accelerator + VPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
-    model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
     batch_size: 1
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
-    model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
-    model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
   }
   delegate_selected: "Neuron RT"
 }
@@ -212,29 +259,37 @@ benchmark_setting {
     delegate_name: "Neuron RT"
     accelerator_name: "neuron"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobile_segmenter_r4_quant_argmax_uint8.dla"
-    model_checksum: "fe62a283e6da531647da15b3f26e680a"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/mobile_segmenter_r4_quant_argmax_uint8.dla"
+      model_checksum: "fe62a283e6da531647da15b3f26e680a"
+    }
   }
   delegate_choice: {
     delegate_name: "Neuron"
     accelerator_name: "neuron"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
-    model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "MediaTek NN accelerator via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
-    model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
-    model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_open/raw/main/vision/mosaic/models_and_checkpoints/R4/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
   }
   delegate_selected: "Neuron RT"
 }
@@ -246,29 +301,37 @@ benchmark_setting {
     delegate_name: "Neuron RT"
     accelerator_name: "neuron"
     accelerator_desc: "MediaTek NN accelerator + CPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/edsr_f32b5_full_qint8.dla"
-    model_checksum: "fcd91d276036be666153c663c03fb69e"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.0-mediatek/edsr_f32b5_full_qint8.dla"
+      model_checksum: "fcd91d276036be666153c663c03fb69e"
+    }
   }
   delegate_choice: {
     delegate_name: "Neuron"
     accelerator_name: "neuron"
     accelerator_desc: "MediaTek NN accelerator + CPU via the Neuron Delegate"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
-    model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
   }
   delegate_choice: {
     delegate_name: "NNAPI"
     accelerator_name: "npu"
     accelerator_desc: "NPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
-    model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
   }
   delegate_choice: {
     delegate_name: "GPU"
     accelerator_name: "gpu"
     accelerator_desc: "GPU"
-    model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
-    model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    model_file: {
+      model_path: "https://github.com/mlcommons/mobile_models/raw/main/v3_0/tflite/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
   }
   delegate_selected: "Neuron RT"
 }


### PR DESCRIPTION
* Closes https://github.com/mlcommons/mobile_app_open/issues/902
* The function signature will stay the same:
```
mlperf_backend_ptr_t mlperf_backend_create(
    const char *model_path, 
    mlperf_backend_configuration_t *configs,
    const char *native_lib_path
)
```
* Here is an example how to have multiple models:
```pbtxt
  delegate_choice: {
    delegate_name: "NNAPI"
    accelerator_name: "npu"
    accelerator_desc: "NPU"
    model_file: {
      model_path: "https://file1.tflite"
      model_checksum: "abc"
    }
    model_file: {
      model_path: "https://file2.tflite"
      model_checksum: "def"
    }
  }
```
  * If there is only one model file, the `model_path` will point to the model file like before.
  * If there are multiple model files, the `model_path` will point to a single directory where all files are located in there.