### PR TITLE
Add a caption_id to coco_gen dataset

### DIFF
--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -229,12 +229,12 @@ task {
     type: COCOGEN
     full {
       name: "COCO validation set for Stable Diffusion"
-      input_path: "https://github.com/anhappdev/tmp/releases/download/5/coco_gen_test.tfrecord"
+      input_path: "https://github.com/anhappdev/tmp/releases/download/6/coco_gen_test.tfrecord"
       groundtruth_path: "local:///mlperf_models/stable-diffusion/clip_model_512x512.tflite"
     }
     lite {
       name: "COCO validation set for Stable Diffusion"
-      input_path: "https://github.com/anhappdev/tmp/releases/download/5/coco_gen_full.tfrecord"
+      input_path: "https://github.com/anhappdev/tmp/releases/download/6/coco_gen_full.tfrecord"
       groundtruth_path: ""
     }
     tiny {

--- a/flutter/cpp/datasets/coco_gen.cc
+++ b/flutter/cpp/datasets/coco_gen.cc
@@ -100,18 +100,20 @@ std::vector<uint8_t> CocoGen::ProcessOutput(const int sample_idx,
     }
   }
 
-  std::string raw_output_filename =
-      raw_output_dir_ + "/output_" + std::to_string(sample_idx) + ".rgb8";
-  dump_output_pixels(output_pixels, raw_output_filename);
-
   if (!output_pixels.empty()) {
     sample_ids_.insert(sample_idx);
     CaptionRecord* record = samples_.at(sample_idx).get();
-    LOG(INFO) << "caption: " << record->get_caption();
-    caption_map[sample_idx] = record->get_caption();
+    LOG(INFO) << "caption_id: " << record->get_caption_id()
+              << " caption_text: " << record->get_caption_text();
+    caption_id_map[sample_idx] = record->get_caption_id();
+    caption_text_map[sample_idx] = record->get_caption_text();
     output_pixels_map[sample_idx] = output_pixels;
     attention_mask_map[sample_idx] = record->get_attention_mask_vector();
     input_ids_map[sample_idx] = record->get_input_ids_vector();
+    std::string raw_output_filename = raw_output_dir_ + "/caption_id_" +
+                                      std::to_string(record->get_caption_id()) +
+                                      ".rgb8";
+    dump_output_pixels(output_pixels, raw_output_filename);
     return output_pixels;
   } else {
     return std::vector<uint8_t>();
@@ -124,7 +126,8 @@ float CocoGen::ComputeAccuracy() {
   float total_score = 0.0f;
   float total_samples = static_cast<float>(sample_ids_.size());
   for (int sample_idx : sample_ids_) {
-    std::string caption = caption_map[sample_idx];
+    int caption_id = caption_id_map[sample_idx];
+    std::string caption_text = caption_text_map[sample_idx];
     std::vector<int32_t> input_ids = input_ids_map[sample_idx];
     std::vector<int32_t> attention_mask = attention_mask_map[sample_idx];
     std::vector<uint8_t> output_pixels = output_pixels_map[sample_idx];
@@ -134,8 +137,8 @@ float CocoGen::ComputeAccuracy() {
     }
     float score =
         score_predictor_.predict(attention_mask, input_ids, pixel_values);
-    LOG(INFO) << "sample_idx: " << sample_idx << " caption: " << caption
-              << " score: " << score;
+    LOG(INFO) << "sample_idx: " << sample_idx << " caption_id: " << caption_id
+              << " caption_text: " << caption_text << " score: " << score;
     total_score += score;
   }
   float avg_score = total_score / total_samples;

--- a/flutter/cpp/datasets/coco_gen.h
+++ b/flutter/cpp/datasets/coco_gen.h
@@ -83,7 +83,8 @@ class CocoGen : public Dataset {
   std::set<int> sample_ids_;
   bool isModelFound;
   std::string raw_output_dir_;
-  std::unordered_map<int, std::string> caption_map;
+  std::unordered_map<int, int> caption_id_map;
+  std::unordered_map<int, std::string> caption_text_map;
   std::unordered_map<int, std::vector<uint8_t>> output_pixels_map;
   std::unordered_map<int, std::vector<int32_t>> attention_mask_map;
   std::unordered_map<int, std::vector<int32_t>> input_ids_map;

--- a/flutter/cpp/datasets/coco_gen_utils/CLIP_Model_to_TFLite.ipynb
+++ b/flutter/cpp/datasets/coco_gen_utils/CLIP_Model_to_TFLite.ipynb
@@ -46,7 +46,7 @@
       "source": [
         "SAVED_MODEL_DIR = './clip_model'\n",
         "TFLITE_MODEL_PATH = './clip_model.tflite'\n",
-        "MODEL_NAME = \"openai/clip-vit-base-patch32\""
+        "MODEL_NAME = \"openai/clip-vit-large-patch14\""
       ],
       "metadata": {
         "id": "eOxB3zL_33tq"

--- a/flutter/cpp/datasets/coco_gen_utils/generate_tfrecords.py
+++ b/flutter/cpp/datasets/coco_gen_utils/generate_tfrecords.py
@@ -56,9 +56,10 @@ def download_image(url, file_path):
     print(f"Downloaded image to {file_path}")
 
 
-def serialize_example(caption, input_ids, attention_mask, file_name, clip_score):
+def serialize_example(caption_id, caption, input_ids, attention_mask, file_name, clip_score):
   """Creates a tf.train.Example message ready to be written to a file."""
   feature = {
+    'caption_id': tf.train.Feature(int64_list=tf.train.Int64List(value=caption_id)),
     'caption': tf.train.Feature(bytes_list=tf.train.BytesList(value=[caption.encode()])),
     'input_ids': tf.train.Feature(int64_list=tf.train.Int64List(value=input_ids)),
     'attention_mask': tf.train.Feature(int64_list=tf.train.Int64List(value=attention_mask)),
@@ -87,6 +88,7 @@ def main():
   with tf.io.TFRecordWriter(args.output_tfrecord, options='ZLIB') as writer:
     total = len(df)
     for idx, row in df.iterrows():
+      caption_id = row['id']
       caption = row['caption']
       file_name = row['file_name']
       coco_url = row['coco_url']
@@ -104,6 +106,7 @@ def main():
       clip_score = outputs.logits_per_image.numpy().flatten().tolist()
 
       example = serialize_example(
+        caption_id=[int(caption_id)],
         caption=caption,
         input_ids=input_ids,
         attention_mask=attention_mask,

--- a/flutter/cpp/datasets/coco_gen_utils/types.h
+++ b/flutter/cpp/datasets/coco_gen_utils/types.h
@@ -29,9 +29,14 @@ struct CaptionRecord {
     tensorflow::Example example;
     example.ParseFromString(record);
 
+    auto caption_id_list =
+        tensorflow::GetFeatureValues<int64_t>("caption_id", example);
+    caption_id =
+        std::vector<int32_t>(caption_id_list.begin(), caption_id_list.end())[0];
+
     auto caption_list =
         tensorflow::GetFeatureValues<string>("caption", example);
-    caption =
+    caption_text =
         std::vector<std::string>(caption_list.begin(), caption_list.end());
 
     auto input_id_list =
@@ -57,7 +62,8 @@ struct CaptionRecord {
 
   void dump() {
     std::cout << "CaptionRecord:\n";
-    std::cout << "  caption: " << get_caption() << "\n";
+    std::cout << "  caption_id: " << get_caption_id() << "\n";
+    std::cout << "  caption_text: " << get_caption_text() << "\n";
     std::cout << "  input_ids: ";
     for (size_t i = 0; i < input_ids.size(); ++i) {
       std::cout << input_ids[i];
@@ -80,7 +86,8 @@ struct CaptionRecord {
     std::cout << "  clip_score: " << clip_score << "\n";
   }
 
-  std::string get_caption() const { return caption[0]; }
+  int get_caption_id() const { return caption_id; }
+  std::string get_caption_text() const { return caption_text[0]; }
   std::string get_filename() const { return filename[0]; }
   int32_t* get_input_ids() { return input_ids.data(); }
   int32_t* get_attention_mask() { return attention_mask.data(); }
@@ -88,7 +95,8 @@ struct CaptionRecord {
   std::vector<int32_t> get_attention_mask_vector() { return attention_mask; }
 
  private:
-  std::vector<std::string> caption;
+  int caption_id;
+  std::vector<std::string> caption_text;
   std::vector<int32_t> input_ids;
   std::vector<int32_t> attention_mask;
   std::vector<std::string> filename;

--- a/mobile_back_apple/dev-utils/Makefile
+++ b/mobile_back_apple/dev-utils/Makefile
@@ -131,9 +131,9 @@ tflite-run-sd:
 	bazel-bin/flutter/cpp/binary/main EXTERNAL stable_diffusion \
 		--mode=PerformanceOnly \
 		--output_dir="${REPO_ROOT_DIR}/output" \
-		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/stable_diffusion/sd-models" \
+		--model_file="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/stable_diffusion/dynamic-sd-models" \
 		--lib_path="bazel-bin/mobile_back_tflite/cpp/backend_tflite/libtflitebackend.so" \
-		--input_tfrecord="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/stable_diffusion/coco_gen_full.tfrecord" \
+		--input_tfrecord="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/stable_diffusion/coco_gen_test.tfrecord" \
 		--input_clip_model="${REPO_ROOT_DIR}/mobile_back_apple/dev-resources/stable_diffusion/clip_model_512x512.tflite" \
 		--min_query_count=5
 


### PR DESCRIPTION
* I added a `caption_id` to the `*.tfrecord` files. The `caption_id` is the `id` field in the captions_source.tsv.
* The `caption_id` will be used as the filename for the image generated by the mobile app.
* With a `caption_id` in filename we can calculate any metrics (e.g. IQA-A) offline and map it with the spreadsheet for analytic purpose.

Relevant files are here:
https://github.com/anhappdev/tmp/releases/tag/6