### PR TITLE
refactor: use custom setting in Core ML backend to detect NCHW input.

### DIFF
--- a/flutter/cpp/utils.h
+++ b/flutter/cpp/utils.h
@@ -69,6 +69,10 @@ SettingList CreateSettingList(const BackendSetting &backend_setting,
                               const std::string &custom_config,
                               const std::string &benchmark_id);
 
+template <typename T>
+T GetConfigValue(mlperf_backend_configuration_t *configs, const char *key,
+                 T defaultValue);
+
 }  // namespace mobile
 }  // namespace mlperf
 

--- a/mobile_back_apple/cpp/backend_coreml/coreml_settings.pbtxt
+++ b/mobile_back_apple/cpp/backend_coreml/coreml_settings.pbtxt
@@ -22,7 +22,7 @@ benchmark_setting {
       model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
     }
   }
-   delegate_choice: {
+  delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
@@ -57,7 +57,7 @@ benchmark_setting {
       model_checksum: "39483b20b878d46144ab4cfe9a3e5600"
     }
   }
-   delegate_choice: {
+  delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
@@ -81,6 +81,10 @@ benchmark_setting {
       model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
       model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
     }
+    custom_setting {
+      id: "data-format"
+      value: "NCHW"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
@@ -90,6 +94,10 @@ benchmark_setting {
       model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
       model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
     }
+    custom_setting {
+      id: "data-format"
+      value: "NCHW"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & ANE"
@@ -98,6 +106,10 @@ benchmark_setting {
     model_file: {
       model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
       model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
+    custom_setting {
+      id: "data-format"
+      value: "NCHW"
     }
   }
   delegate_selected: "CPU & GPU & ANE"
@@ -115,6 +127,10 @@ benchmark_setting {
       model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
       model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
     }
+    custom_setting {
+      id: "data-format"
+      value: "NCHW"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & GPU"
@@ -125,6 +141,10 @@ benchmark_setting {
       model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
       model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
     }
+    custom_setting {
+      id: "data-format"
+      value: "NCHW"
+    }
   }
   delegate_choice: {
     delegate_name: "CPU & ANE"
@@ -134,6 +154,10 @@ benchmark_setting {
     model_file: {
       model_path: "https://github.com/mlcommons/mobile_models/releases/download/v4.1-coreml/mobilenetv4_fp32_NCHW.mlpackage.zip"
       model_checksum: "164c504eb3e9af6c730c1765b8b81b32"
+    }
+    custom_setting {
+      id: "data-format"
+      value: "NCHW"
     }
   }
   delegate_selected: "CPU & GPU & ANE"
@@ -160,7 +184,7 @@ benchmark_setting {
       model_checksum: "ef849fbf2132e205158f05ca42db25f4"
     }
   }
-   delegate_choice: {
+  delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
@@ -217,7 +241,7 @@ benchmark_setting {
       model_checksum: "362d6b5bb1b8e10ae5b4e223f60d4d10"
     }
   }
-   delegate_choice: {
+  delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"
@@ -250,7 +274,7 @@ benchmark_setting {
       model_checksum: "62489706f20b0c2ae561fb2204eefb61"
     }
   }
-   delegate_choice: {
+  delegate_choice: {
     delegate_name: "CPU & ANE"
     accelerator_name: "cpu&ane"
     accelerator_desc: "CPU and Neural Engine"

--- a/mobile_back_apple/cpp/backend_coreml/main.cc
+++ b/mobile_back_apple/cpp/backend_coreml/main.cc
@@ -101,8 +101,9 @@ mlperf_backend_ptr_t mlperf_backend_create(
 
   CoreMLBackendData *backend_data = new CoreMLBackendData();
   backendExists = true;
-  // quick hack for checking if model expects NCHW input.
-  if (strcasestr(model_path, "NCHW") != nullptr) {
+  std::string dataFormat =
+      mlperf::mobile::GetConfigValue(configs, "data-format", std::string(""));
+  if (dataFormat == "NCHW") {
     backend_data->expectNCHW = true;
     LOG(INFO) << "Will convert inputs from NHWC to NCHW!";
   }

--- a/mobile_back_apple/dev-utils/Makefile
+++ b/mobile_back_apple/dev-utils/Makefile
@@ -24,7 +24,7 @@ app:
 
 tflite-build:
 	cd ${REPO_ROOT_DIR} && \
-	bazel build -c opt --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --macos_minimum_os=12.1 \
+	bazel build -c opt --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --macos_minimum_os=13.1 \
 	//flutter/cpp/binary:main //mobile_back_tflite:tflitebackend
 
 tflite-run-ic:
@@ -141,7 +141,7 @@ tflite-run-sd:
 
 coreml-build:
 	cd ${REPO_ROOT_DIR} && \
-	bazel build -c opt --cxxopt=-fobjc-arc --cxxopt=-xobjective-c++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --macos_minimum_os=12.1 \
+	bazel build -c opt --cxxopt=-fobjc-arc --cxxopt=-xobjective-c++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --macos_minimum_os=13.1 \
 	//flutter/cpp/binary:main //mobile_back_apple:coremlbackend
 
 coreml-run-ic:

--- a/mobile_back_tflite/cpp/backend_tflite/BUILD
+++ b/mobile_back_tflite/cpp/backend_tflite/BUILD
@@ -68,6 +68,7 @@ cc_library(
     }),
     deps = [
         ":tflite_settings",
+        "//flutter/cpp:utils",
         "//flutter/cpp/c:headers",
         "@org_tensorflow//tensorflow/core:tflite_portable_logging",
         "@org_tensorflow//tensorflow/lite/c:c_api",

--- a/mobile_back_tflite/cpp/backend_tflite/neuron/BUILD
+++ b/mobile_back_tflite/cpp/backend_tflite/neuron/BUILD
@@ -70,6 +70,7 @@ cc_library(
     local_defines = ["MTK_TFLITE_NEURON_BACKEND"],
     deps = [
         ":tflite_settings",
+        "//flutter/cpp:utils",
         "//flutter/cpp/c:headers",
         "//mobile_back_tflite/cpp/backend_tflite:tflite_settings",
         "@org_tensorflow//tensorflow/core:tflite_portable_logging",


### PR DESCRIPTION
The Core ML backend now uses
```
custom_setting {
      id: "data-format"
      value: "NCHW"
}
```
instead of hard-coded file name like `mobilenetv4_fp32_NCHW` to detect NCHW input.

I also add a `GetConfigValue()` method to easily read the config values.
