### PR TITLE
fix: resolve crash due to permission denied on Android Play Store version

### DIFF
--- a/flutter/android/app/src/main/AndroidManifest.xml
+++ b/flutter/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
                    android:maxSdkVersion="29"/>
 
   <application android:label="MLPerf Mobile"
-               android:icon="@mipmap/ic_launcher">
+               android:icon="@mipmap/ic_launcher"
+               android:extractNativeLibs="true">
 
     <!-- TFLite -->
     <uses-library android:name="libOpenCL.so"

--- a/flutter/android/gradle.properties
+++ b/flutter/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.bundle.enableUncompressedNativeLibs=false


### PR DESCRIPTION
* Closes https://github.com/mlcommons/mobile_app_open/issues/893

1. Set `android:extractNativeLibs="true"` as in https://stackoverflow.com/a/64792194
2. Set `android.bundle.enableUncompressedNativeLibs=false` as in https://stackoverflow.com/a/56551499