### PR TITLE
feat: add quick run mode

### DIFF
--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -42,11 +42,7 @@ flutter run
 If you want to run or debug the Flutter app for any platform using graphical user interface,
 you can use [VS Code with Flutter extension](https://docs.flutter.dev/get-started/editor?tab=vscode).
 
-If you want to test something without spending a lot of time on the benchmark,
-you can use flag `--dart-define=FAST_MODE=true` to speed up the benchmark.
-You should not evaluate performance when using this flag.
-
-Add `WITH_<VENDOR>=1` to make commands to build the the app with backends.
+Add `WITH_<VENDOR>=1` to make commands to build the app with certain backends.
 For example:
 
 ```bash

--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -20,8 +20,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {
@@ -77,8 +77,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {
@@ -134,8 +134,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {
@@ -190,8 +190,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {
@@ -243,8 +243,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {
@@ -298,8 +298,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {
@@ -355,8 +355,8 @@ task {
     }
     rapid {
       min_query_count: 64
-      min_duration: 1
-      max_duration: 600
+      min_duration: 6
+      max_duration: 60
     }
   }
   datasets {

--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -4,12 +4,26 @@
 task {
   id: "image_classification_v2"
   name: "Image Classification v2"
-  min_query_count: 1024
-  min_duration: 60
-  max_duration: 600
   max_throughput: 1000
   max_accuracy: 1.0
   scenario: "SingleStream"
+  runs {
+    normal {
+      min_query_count: 1024
+      min_duration: 60
+      max_duration: 600
+    }
+    quick {
+      min_query_count: 128
+      min_duration: 6
+      max_duration: 60
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: IMAGENET
     full {
@@ -47,12 +61,26 @@ task {
 task {
   id: "object_detection"
   name: "Object Detection"
-  min_query_count: 1024
-  min_duration: 60
-  max_duration: 600
   max_throughput: 2000
   max_accuracy: 1.0
   scenario: "SingleStream"
+  runs {
+    normal {
+      min_query_count: 1024
+      min_duration: 60
+      max_duration: 600
+    }
+    quick {
+      min_query_count: 128
+      min_duration: 6
+      max_duration: 60
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: COCO
     full {
@@ -90,12 +118,26 @@ task {
 task {
   id: "image_segmentation_v2"
   name: "Image Segmentation v2"
-  min_query_count: 1024
-  min_duration: 60
-  max_duration: 600
   max_throughput: 2000
   max_accuracy: 1.0
   scenario: "SingleStream"
+  runs {
+    normal {
+      min_query_count: 1024
+      min_duration: 60
+      max_duration: 600
+    }
+    quick {
+      min_query_count: 128
+      min_duration: 6
+      max_duration: 60
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: ADE20K
     full {
@@ -132,12 +174,26 @@ task {
 task {
   id: "natural_language_processing"
   name: "Language Understanding"
-  min_query_count: 1024
-  min_duration: 60
-  max_duration: 600
   max_throughput: 2000
   max_accuracy: 1.0
   scenario: "SingleStream"
+  runs {
+    normal {
+      min_query_count: 1024
+      min_duration: 60
+      max_duration: 600
+    }
+    quick {
+      min_query_count: 128
+      min_duration: 6
+      max_duration: 60
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: SQUAD
     full {
@@ -171,12 +227,26 @@ task {
 task {
   id: "super_resolution"
   name: "Super Resolution "
-  min_query_count: 1024
-  min_duration: 60
-  max_duration: 600
   max_throughput: 2000
   max_accuracy: 1.0
   scenario: "SingleStream"
+  runs {
+    normal {
+      min_query_count: 1024
+      min_duration: 60
+      max_duration: 600
+    }
+    quick {
+      min_query_count: 128
+      min_duration: 6
+      max_duration: 60
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: SNUSR
     full {
@@ -212,12 +282,26 @@ task {
 task {
   id: "image_classification_offline_v2"
   name: "Image Classification v2 (Offline)"
-  min_query_count: 24576
-  min_duration: 0
-  max_duration: 0
   max_throughput: 2000
   max_accuracy: 1.0
   scenario: "Offline"
+  runs {
+    normal {
+      min_query_count: 24576
+      min_duration: 0
+      max_duration: 0
+    }
+    quick {
+      min_query_count: 2457
+      min_duration: 0
+      max_duration: 0
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: IMAGENET
     full {
@@ -255,12 +339,26 @@ task {
 task {
   id: "stable_diffusion"
   name: "Stable Diffusion"
-  min_query_count: 1024
-  min_duration: 60
-  max_duration: 300
   max_throughput: 2000
   max_accuracy: 1.0
   scenario: "SingleStream"
+  runs {
+    normal {
+      min_query_count: 1024
+      min_duration: 60
+      max_duration: 300
+    }
+    quick {
+      min_query_count: 128
+      min_duration: 6
+      max_duration: 30
+    }
+    rapid {
+      min_query_count: 64
+      min_duration: 1
+      max_duration: 600
+    }
+  }
   datasets {
     type: COCOGEN
     full {

--- a/flutter/cpp/proto/mlperf_task.proto
+++ b/flutter/cpp/proto/mlperf_task.proto
@@ -31,28 +31,40 @@ message MLPerfConfig {
 // Config of the mlperf tasks.
 // A task is basically a combination of models and a dataset.
 //
-// Next ID: 12
+// Next ID: 13
 message TaskConfig {
   // Must be unique in one task file. Ex: image_classification
   // used to match backend settings
   required string id = 1;
   // Human-readable name. Ex: Image classification.
   required string name = 2;
-  // Minimum number of samples the test should run in the performance mode.
-  required int32 min_query_count = 3;
-  // Minimum duration the test should run in the performance mode, in seconds.
-  required double min_duration = 4 [default = 60];
-  // Maximum duration the test should run in the performance mode, in seconds.
-  required double max_duration = 10 [default = 600];
   // Max expected throughput score
   required float max_throughput = 5;
   // Max expected accuracy
   required float max_accuracy = 6;
   // LoadGen parameter. Allowed values: SingleStream, Offline
   required string scenario = 7;
+  required RunConfig runs = 12;
   required DatasetConfig datasets = 8;
   required ModelConfig model = 9;
   repeated CustomConfig custom_config = 11;
+}
+
+// Run configurations
+message RunConfig {
+  required OneRunConfig normal = 1;
+  required OneRunConfig quick = 2;
+  required OneRunConfig rapid = 3;
+}
+
+// Config of one run
+message OneRunConfig {
+  // Minimum number of samples the test should run in the performance mode.
+  required int32 min_query_count = 3;
+  // Minimum duration the test should run in the performance mode, in seconds.
+  required double min_duration = 4 [default = 60];
+  // Maximum duration the test should run in the performance mode, in seconds.
+  required double max_duration = 10 [default = 600];
 }
 
 // Datasets for a task

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -19,17 +19,9 @@ void main() {
   binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
 
   final prefs = <String, Object>{
-    StoreConstants.testMode: true,
     StoreConstants.selectedBenchmarkRunMode:
-        BenchmarkRunModeEnum.submissionRun.name,
-    StoreConstants.testMinDuration: 1,
-    StoreConstants.testMinQueryCount: 4,
+        BenchmarkRunModeEnum.integrationTestRun.name,
   };
-  if (DartDefine.perfTestEnabled) {
-    prefs[StoreConstants.testMinDuration] = 15;
-    prefs[StoreConstants.testMinQueryCount] = 64;
-    prefs[StoreConstants.testCooldownDuration] = 2;
-  }
   SharedPreferences.setMockInitialValues(prefs);
 
   group('integration tests', () {
@@ -67,9 +59,7 @@ void checkTasks(ExtendedResult extendedResult) {
     expect(benchmarkResult.performanceRun!.throughput, isNotNull);
 
     checkAccuracy(benchmarkResult);
-    if (DartDefine.perfTestEnabled) {
-      checkThroughput(benchmarkResult, extendedResult.environmentInfo);
-    }
+    checkThroughput(benchmarkResult, extendedResult.environmentInfo);
   }
 }
 

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -21,6 +21,9 @@ void main() {
   final prefs = <String, Object>{
     StoreConstants.selectedBenchmarkRunMode:
         BenchmarkRunModeEnum.integrationTestRun.name,
+    StoreConstants.cooldown: true,
+    StoreConstants.cooldownDuration:
+        BenchmarkRunModeEnum.integrationTestRun.cooldownDuration,
   };
   SharedPreferences.setMockInitialValues(prefs);
 

--- a/flutter/lib/app_constants.dart
+++ b/flutter/lib/app_constants.dart
@@ -5,9 +5,6 @@ class DartDefine {
       bool.fromEnvironment('OFFICIAL_BUILD', defaultValue: false);
   static const firebaseCrashlyticsEnabled =
       bool.fromEnvironment('FIREBASE_CRASHLYTICS_ENABLED', defaultValue: false);
-  static const isFastMode =
-      bool.fromEnvironment('FAST_MODE', defaultValue: false);
-
   static const perfTestEnabled =
       bool.fromEnvironment('PERF_TEST', defaultValue: false);
 }

--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 
-import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/backend/bridge/run_settings.dart';
 import 'package:mlperfbench/backend/loadgen_info.dart';
 import 'package:mlperfbench/benchmark/info.dart';
@@ -69,24 +68,13 @@ class Benchmark {
     required List<pb.CommonSetting> commonSettings,
     required String backendLibName,
     required String logDir,
-    required int testMinDuration,
-    required int testMinQueryCount,
   }) async {
     final dataset = runMode.chooseDataset(taskConfig);
+    final runConfig = runMode.chooseRunConfig(taskConfig);
 
-    int minQueryCount;
-    double minDuration;
-    if (testMinDuration != 0) {
-      minQueryCount = testMinQueryCount;
-      minDuration = testMinDuration.toDouble();
-    } else if (DartDefine.isFastMode) {
-      minQueryCount = 8;
-      minDuration = 1.0;
-    } else {
-      minQueryCount = taskConfig.minQueryCount;
-      minDuration = taskConfig.minDuration;
-    }
-    double maxDuration = taskConfig.maxDuration;
+    int minQueryCount = runConfig.minQueryCount;
+    double minDuration = runConfig.minDuration;
+    double maxDuration = runConfig.maxDuration;
 
     final settings = pb.SettingList(
       setting: commonSettings,
@@ -114,7 +102,7 @@ class Benchmark {
       model_image_width: taskConfig.model.imageWidth,
       model_image_height: taskConfig.model.imageHeight,
       scenario: taskConfig.scenario,
-      mode: runMode.loadgenMode,
+      mode: runMode.loadgenMode.name,
       batch_size: selectedDelegate.batchSize,
       min_query_count: minQueryCount,
       min_duration: minDuration,

--- a/flutter/lib/benchmark/run_mode.dart
+++ b/flutter/lib/benchmark/run_mode.dart
@@ -96,6 +96,15 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
     }
   }
 
+  bool get isHiddenFromUI {
+    switch (this) {
+      case BenchmarkRunModeEnum.integrationTestRun:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   BenchmarkRunMode get performanceRunMode {
     BenchmarkRunMode mode = BenchmarkRunMode._(
       loadgenMode: LoadgenModeEnum.performanceOnly,

--- a/flutter/lib/benchmark/run_mode.dart
+++ b/flutter/lib/benchmark/run_mode.dart
@@ -120,7 +120,7 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
         break;
       case BenchmarkRunModeEnum.integrationTestRun:
         mode.chooseDataset = (pb.TaskConfig t) => t.datasets.tiny;
-        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.test;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.rapid;
         break;
     }
     return mode;
@@ -150,7 +150,7 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
         break;
       case BenchmarkRunModeEnum.integrationTestRun:
         mode.chooseDataset = (pb.TaskConfig t) => t.datasets.tiny;
-        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.test;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.rapid;
         break;
     }
     return mode;
@@ -178,5 +178,20 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
         break;
     }
     return modes;
+  }
+
+  int get cooldownDuration {
+    switch (this) {
+      case BenchmarkRunModeEnum.performanceOnly:
+        return 5 * 60;
+      case BenchmarkRunModeEnum.accuracyOnly:
+        return 2;
+      case BenchmarkRunModeEnum.submissionRun:
+        return 5 * 60;
+      case BenchmarkRunModeEnum.quickRun:
+        return 1 * 60;
+      case BenchmarkRunModeEnum.integrationTestRun:
+        return 5;
+    }
   }
 }

--- a/flutter/lib/benchmark/run_mode.dart
+++ b/flutter/lib/benchmark/run_mode.dart
@@ -1,44 +1,24 @@
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/protos/mlperf_task.pb.dart' as pb;
 
+const _performanceModeString = 'PerformanceOnly';
+const _accuracyModeString = 'AccuracyOnly';
+
+const _perfLogSuffix = 'performance';
+const _accuracyLogSuffix = 'accuracy';
+
 class BenchmarkRunMode {
-  static const _performanceModeString = 'PerformanceOnly';
-  static const _accuracyModeString = 'AccuracyOnly';
-
-  static const _perfLogSuffix = 'performance';
-  static const _accuracyLogSuffix = 'accuracy';
-
-  final String loadgenMode;
+  final LoadgenModeEnum loadgenMode;
   final String readable;
-  final pb.OneDatasetConfig Function(pb.TaskConfig taskConfig) chooseDataset;
+  late final pb.OneDatasetConfig Function(pb.TaskConfig t) chooseDataset;
+  late final pb.OneRunConfig Function(pb.TaskConfig t) chooseRunConfig;
+
+  // final int coolDownDuration;
 
   BenchmarkRunMode._({
     required this.loadgenMode,
     required this.readable,
-    required this.chooseDataset,
   });
-
-  static BenchmarkRunMode performance = BenchmarkRunMode._(
-    loadgenMode: _performanceModeString,
-    readable: _perfLogSuffix,
-    chooseDataset: (task) => task.datasets.lite,
-  );
-  static BenchmarkRunMode accuracy = BenchmarkRunMode._(
-    loadgenMode: _accuracyModeString,
-    readable: _accuracyLogSuffix,
-    chooseDataset: (task) => task.datasets.full,
-  );
-
-  static BenchmarkRunMode performanceTest = BenchmarkRunMode._(
-    loadgenMode: _performanceModeString,
-    readable: _perfLogSuffix,
-    chooseDataset: (task) => task.datasets.tiny,
-  );
-  static BenchmarkRunMode accuracyTest = BenchmarkRunMode._(
-    loadgenMode: _accuracyModeString,
-    readable: _accuracyLogSuffix,
-    chooseDataset: (task) => task.datasets.tiny,
-  );
 
   @override
   String toString() {
@@ -46,10 +26,28 @@ class BenchmarkRunMode {
   }
 }
 
+enum LoadgenModeEnum {
+  performanceOnly,
+  accuracyOnly,
+}
+
+extension LoadgenModeEnumExtension on LoadgenModeEnum {
+  String get name {
+    switch (this) {
+      case LoadgenModeEnum.performanceOnly:
+        return _performanceModeString;
+      case LoadgenModeEnum.accuracyOnly:
+        return _accuracyModeString;
+    }
+  }
+}
+
 enum BenchmarkRunModeEnum {
   performanceOnly,
   accuracyOnly,
   submissionRun,
+  quickRun,
+  integrationTestRun
 }
 
 extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
@@ -60,6 +58,10 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
       case BenchmarkRunModeEnum.accuracyOnly:
         return false;
       case BenchmarkRunModeEnum.submissionRun:
+        return true;
+      case BenchmarkRunModeEnum.quickRun:
+        return true;
+      case BenchmarkRunModeEnum.integrationTestRun:
         return true;
     }
   }
@@ -72,6 +74,10 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
         return true;
       case BenchmarkRunModeEnum.submissionRun:
         return true;
+      case BenchmarkRunModeEnum.quickRun:
+        return false;
+      case BenchmarkRunModeEnum.integrationTestRun:
+        return true;
     }
   }
 
@@ -83,6 +89,94 @@ extension BenchmarkRunModeEnumExtension on BenchmarkRunModeEnum {
         return l10n.benchModeAccuracyOnly;
       case BenchmarkRunModeEnum.submissionRun:
         return l10n.benchModeSubmissionRun;
+      case BenchmarkRunModeEnum.quickRun:
+        return l10n.benchModeQuickRun;
+      case BenchmarkRunModeEnum.integrationTestRun:
+        return l10n.benchModeIntegrationTestRun;
     }
+  }
+
+  BenchmarkRunMode get performanceRunMode {
+    BenchmarkRunMode mode = BenchmarkRunMode._(
+      loadgenMode: LoadgenModeEnum.performanceOnly,
+      readable: _perfLogSuffix,
+    );
+    switch (this) {
+      case BenchmarkRunModeEnum.performanceOnly:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.lite;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.normal;
+        break;
+      case BenchmarkRunModeEnum.accuracyOnly:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.lite;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.normal;
+        break;
+      case BenchmarkRunModeEnum.submissionRun:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.lite;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.normal;
+        break;
+      case BenchmarkRunModeEnum.quickRun:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.lite;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.quick;
+        break;
+      case BenchmarkRunModeEnum.integrationTestRun:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.tiny;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.test;
+        break;
+    }
+    return mode;
+  }
+
+  BenchmarkRunMode get accuracyRunMode {
+    BenchmarkRunMode mode = BenchmarkRunMode._(
+      loadgenMode: LoadgenModeEnum.accuracyOnly,
+      readable: _accuracyLogSuffix,
+    );
+    switch (this) {
+      case BenchmarkRunModeEnum.performanceOnly:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.full;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.normal;
+        break;
+      case BenchmarkRunModeEnum.accuracyOnly:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.full;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.normal;
+        break;
+      case BenchmarkRunModeEnum.submissionRun:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.full;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.normal;
+        break;
+      case BenchmarkRunModeEnum.quickRun:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.full;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.quick;
+        break;
+      case BenchmarkRunModeEnum.integrationTestRun:
+        mode.chooseDataset = (pb.TaskConfig t) => t.datasets.tiny;
+        mode.chooseRunConfig = (pb.TaskConfig t) => t.runs.test;
+        break;
+    }
+    return mode;
+  }
+
+  List<BenchmarkRunMode> get selectedRunModes {
+    final modes = <BenchmarkRunMode>[];
+    switch (this) {
+      case BenchmarkRunModeEnum.performanceOnly:
+        modes.add(performanceRunMode);
+        break;
+      case BenchmarkRunModeEnum.accuracyOnly:
+        modes.add(accuracyRunMode);
+        break;
+      case BenchmarkRunModeEnum.submissionRun:
+        modes.add(performanceRunMode);
+        modes.add(accuracyRunMode);
+        break;
+      case BenchmarkRunModeEnum.quickRun:
+        modes.add(performanceRunMode);
+        break;
+      case BenchmarkRunModeEnum.integrationTestRun:
+        modes.add(performanceRunMode);
+        modes.add(accuracyRunMode);
+        break;
+    }
+    return modes;
   }
 }

--- a/flutter/lib/build_info.dart
+++ b/flutter/lib/build_info.dart
@@ -22,7 +22,7 @@ class BuildInfoHelper {
         buildNumber: packageInfo.buildNumber,
         buildDate: DateTime.now(),
         officialReleaseFlag: DartDefine.isOfficialBuild,
-        devTestFlag: DartDefine.isFastMode,
+        devTestFlag: DartDefine.perfTestEnabled,
         backendList: BackendInfoHelper().getBackendsList(),
         gitBranch: GeneratedBuildInfo.gitBranch,
         gitCommit: GeneratedBuildInfo.gitCommit,

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -70,7 +70,7 @@
   "settingsKeepLogs": "Keep logs",
   "settingsKeepLogsSubtitle": "Keep loadgen logs of future runs.\nThis option doesn't affect past logs.",
   "settingsCooldown": "Cooldown",
-  "settingsCooldownSubtitle": "Pause <cooldownPause> minutes before running each benchmark to avoid thermal throttling.",
+  "settingsCooldownSubtitle": "Pause <cooldownPause> seconds before running next benchmark to avoid thermal throttling.",
   "settingsPrivacyPolicy": "Privacy Policy",
   "settingsEula": "End User License Agreement",
   "settingsTaskConfigTitle": "Task configuration",

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -91,6 +91,7 @@
   "dialogTitleConfirm": "Confirm?",
   "dialogContentOfflineWarning": "Offline mode is enabled but following internet resources are defined in the configuration. Do you want to continue?",
   "dialogContentMissingFiles": "The following files don't exist:",
+  "dialogContentMissingFilesHint": "Please go to the menu Resources to download the missing files.",
   "dialogContentChecksumError": "The following files failed checksum validation:",
   "dialogContentNoSelectedBenchmarkError": "Please select at least one benchmark.",
 
@@ -98,6 +99,8 @@
   "benchModePerformanceOnly": "Performance Only",
   "benchModeAccuracyOnly": "Accuracy Only",
   "benchModeSubmissionRun": "Submission Run",
+  "benchModeQuickRun": "Quick Run",
+  "benchModeIntegrationTestRun": "Integration Test Run",
   "benchNameImageClassification": "Image Classification",
   "benchNameObjectDetection": "Object detection",
   "benchNameImageSegmentation": "Image Segmentation",

--- a/flutter/lib/resources/export_result_helper.dart
+++ b/flutter/lib/resources/export_result_helper.dart
@@ -35,13 +35,18 @@ class ResultHelper {
       throw 'One of performanceRunInfo or accuracyRunInfo must not be null';
     }
     final commonSettings = runInfo.settings.backend_settings.setting;
+    final performanceModeRunConfig =
+        performanceMode.chooseRunConfig(benchmark.taskConfig);
+    final accuracyModeRunConfig =
+        accuracyMode.chooseRunConfig(benchmark.taskConfig);
+    assert(performanceModeRunConfig == accuracyModeRunConfig);
     return BenchmarkExportResult(
       benchmarkId: benchmark.id,
       benchmarkName: benchmark.taskConfig.name,
       performanceRun: _makeRunResult(performanceRunInfo, performanceMode),
       accuracyRun: _makeRunResult(accuracyRunInfo, accuracyMode),
-      minDuration: benchmark.taskConfig.minDuration,
-      minSamples: benchmark.taskConfig.minQueryCount,
+      minDuration: performanceModeRunConfig.minDuration,
+      minSamples: performanceModeRunConfig.minQueryCount,
       backendInfo: _makeBackendInfo(runInfo.result),
       backendSettings: _makeBackendSettingsInfo(benchmark, commonSettings),
       loadgenScenario: BenchmarkExportResult.parseLoadgenScenario(

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -78,7 +78,7 @@ class TaskRunner {
       BenchmarkStore benchmarkStore, String currentLogDir) async {
     progressInfo = ProgressInfo();
     final cooldown = store.cooldown;
-    final cooldownDuration = Duration(minutes: store.cooldownDuration);
+    final cooldownDuration = Duration(seconds: store.cooldownDuration);
 
     final activeBenchmarks =
         benchmarkStore.benchmarks.where((element) => element.isActive);

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -174,14 +174,11 @@ class TaskRunner {
       progressInfo.calculateStageProgress = () {
         // UI updates once per second so using 1 second as lower bound should not affect it.
         final minDuration = max(taskMinDuration, 1);
-        final timeProgress = perfTimer.elapsedMilliseconds /
-            Duration.millisecondsPerSecond /
-            minDuration;
-
+        final timeProgress = perfTimer.elapsed.inSeconds / minDuration;
         final minQueries = max(taskMinQueryCount, 1);
         final queryCounter = backendBridge.getQueryCounter();
         final queryProgress =
-            queryCounter < 0 ? 1.0 : queryCounter / minQueries;
+            queryCounter < 0 ? 0.0 : queryCounter / minQueries;
         return min(timeProgress, queryProgress);
       };
       notifyListeners();

--- a/flutter/lib/state/task_runner.dart
+++ b/flutter/lib/state/task_runner.dart
@@ -5,7 +5,6 @@ import 'package:async/async.dart';
 import 'package:uuid/uuid.dart';
 import 'package:worker_manager/worker_manager.dart';
 
-import 'package:mlperfbench/app_constants.dart';
 import 'package:mlperfbench/backend/bridge/isolate.dart';
 import 'package:mlperfbench/backend/bridge/run_result.dart';
 import 'package:mlperfbench/backend/bridge/run_settings.dart';
@@ -60,30 +59,14 @@ class TaskRunner {
     required this.backendInfo,
   });
 
-  BenchmarkRunMode get perfMode => store.testMode
-      ? BenchmarkRunMode.performanceTest
-      : BenchmarkRunMode.performance;
+  BenchmarkRunMode get perfMode =>
+      store.selectedBenchmarkRunMode.performanceRunMode;
 
-  BenchmarkRunMode get accuracyMode => store.testMode
-      ? BenchmarkRunMode.accuracyTest
-      : BenchmarkRunMode.accuracy;
+  BenchmarkRunMode get accuracyMode =>
+      store.selectedBenchmarkRunMode.accuracyRunMode;
 
-  List<BenchmarkRunMode> get selectedRunModes {
-    final modes = <BenchmarkRunMode>[];
-    switch (store.selectedBenchmarkRunMode) {
-      case BenchmarkRunModeEnum.performanceOnly:
-        modes.add(perfMode);
-        break;
-      case BenchmarkRunModeEnum.accuracyOnly:
-        modes.add(accuracyMode);
-        break;
-      case BenchmarkRunModeEnum.submissionRun:
-        modes.add(perfMode);
-        modes.add(accuracyMode);
-        break;
-    }
-    return modes;
-  }
+  List<BenchmarkRunMode> get selectedRunModes =>
+      store.selectedBenchmarkRunMode.selectedRunModes;
 
   Future<void> abortBenchmarks() async {
     aborting = true;
@@ -95,14 +78,7 @@ class TaskRunner {
       BenchmarkStore benchmarkStore, String currentLogDir) async {
     progressInfo = ProgressInfo();
     final cooldown = store.cooldown;
-    late final Duration cooldownDuration;
-    if (store.testMode) {
-      cooldownDuration = Duration(seconds: store.testCooldown);
-    } else if (DartDefine.isFastMode) {
-      cooldownDuration = const Duration(seconds: 1);
-    } else {
-      cooldownDuration = Duration(minutes: store.cooldownDuration);
-    }
+    final cooldownDuration = Duration(minutes: store.cooldownDuration);
 
     final activeBenchmarks =
         benchmarkStore.benchmarks.where((element) => element.isActive);
@@ -118,18 +94,10 @@ class TaskRunner {
       resultHelpers.add(resultHelper);
     }
 
+    print('Starting in run mode: ${store.selectedBenchmarkRunMode}');
     progressInfo.runMode = store.selectedBenchmarkRunMode;
-    switch (store.selectedBenchmarkRunMode) {
-      case BenchmarkRunModeEnum.performanceOnly:
-        progressInfo.totalStages = activeBenchmarks.length;
-        break;
-      case BenchmarkRunModeEnum.accuracyOnly:
-        progressInfo.totalStages = activeBenchmarks.length;
-        break;
-      case BenchmarkRunModeEnum.submissionRun:
-        progressInfo.totalStages = 2 * activeBenchmarks.length;
-        break;
-    }
+    progressInfo.totalStages =
+        selectedRunModes.length * activeBenchmarks.length;
 
     progressInfo.currentStage = 0;
     progressInfo.cooldownDuration = cooldownDuration.inSeconds.toDouble();
@@ -196,18 +164,21 @@ class TaskRunner {
     final benchmark = resultHelper.benchmark;
     progressInfo.currentBenchmark = benchmark.info;
     progressInfo.currentStage++;
-
-    if (mode == perfMode) {
+    if (mode.loadgenMode == LoadgenModeEnum.performanceOnly) {
       final perfTimer = Stopwatch()..start();
       progressInfo.accuracy = false;
+      double taskMinDuration =
+          mode.chooseRunConfig(benchmark.taskConfig).minDuration;
+      int taskMinQueryCount =
+          mode.chooseRunConfig(benchmark.taskConfig).minQueryCount;
       progressInfo.calculateStageProgress = () {
         // UI updates once per second so using 1 second as lower bound should not affect it.
-        final minDuration = max(benchmark.taskConfig.minDuration, 1);
+        final minDuration = max(taskMinDuration, 1);
         final timeProgress = perfTimer.elapsedMilliseconds /
             Duration.millisecondsPerSecond /
             minDuration;
 
-        final minQueries = max(benchmark.taskConfig.minQueryCount, 1);
+        final minQueries = max(taskMinQueryCount, 1);
         final queryCounter = backendBridge.getQueryCounter();
         final queryProgress =
             queryCounter < 0 ? 1.0 : queryCounter / minQueries;
@@ -226,8 +197,6 @@ class TaskRunner {
         resourceManager: resourceManager,
         commonSettings: backendInfo.settings.commonSetting,
         backendLibName: backendInfo.libName,
-        testMinQueryCount: store.testMinQueryCount,
-        testMinDuration: store.testMinDuration,
       );
       final performanceRunInfo = await runHelper.run();
       perfTimer.stop();
@@ -245,7 +214,7 @@ class TaskRunner {
         loadgenInfo: performanceRunInfo.loadgenInfo!,
       );
       resultHelper.performanceRunInfo = performanceRunInfo;
-    } else if (mode == accuracyMode) {
+    } else if (mode.loadgenMode == LoadgenModeEnum.accuracyOnly) {
       progressInfo.accuracy = true;
       progressInfo.calculateStageProgress = () {
         final queryCounter = backendBridge.getQueryCounter();
@@ -266,8 +235,6 @@ class TaskRunner {
         resourceManager: resourceManager,
         commonSettings: backendInfo.settings.commonSetting,
         backendLibName: backendInfo.libName,
-        testMinQueryCount: store.testMinQueryCount,
-        testMinDuration: store.testMinDuration,
       );
       final accuracyRunInfo = await runHelper.run();
       resultHelper.accuracyRunInfo = accuracyRunInfo;
@@ -285,6 +252,7 @@ class TaskRunner {
         loadgenInfo: accuracyRunInfo.loadgenInfo,
       );
     } else {
+      print('Unknown BenchmarkRunMode: $mode');
       throw 'Unknown BenchmarkRunMode: $mode';
     }
     progressInfo.completedBenchmarks.add(benchmark.info);
@@ -313,8 +281,6 @@ class _NativeRunHelper {
     required ResourceManager resourceManager,
     required List<pb.CommonSetting> commonSettings,
     required String backendLibName,
-    required int testMinQueryCount,
-    required int testMinDuration,
   }) async {
     runSettings = await benchmark.createRunSettings(
       runMode: runMode,
@@ -322,8 +288,6 @@ class _NativeRunHelper {
       commonSettings: commonSettings,
       backendLibName: backendLibName,
       logDir: logDir,
-      testMinQueryCount: testMinQueryCount,
-      testMinDuration: testMinDuration,
     );
   }
 

--- a/flutter/lib/store.dart
+++ b/flutter/lib/store.dart
@@ -56,13 +56,6 @@ class Store extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool get testMode => _getBool(StoreConstants.testMode);
-
-  set testMode(bool value) {
-    _storeFromDisk.setBool(StoreConstants.testMode, value);
-    notifyListeners();
-  }
-
   bool get cooldown => _getBool(StoreConstants.cooldown, true);
 
   set cooldown(bool value) {
@@ -119,12 +112,6 @@ class Store extends ChangeNotifier {
     _storeFromDisk.setBool(StoreConstants.crashlyticsEnabled, value);
     notifyListeners();
   }
-
-  int get testMinDuration => _getInt(StoreConstants.testMinDuration);
-
-  int get testCooldown => _getInt(StoreConstants.testCooldownDuration);
-
-  int get testMinQueryCount => _getInt(StoreConstants.testMinQueryCount);
 }
 
 class StoreConstants {
@@ -139,8 +126,5 @@ class StoreConstants {
   static const previousAppVersion = 'previous app version';
   static const keepLogs = 'keep_logs';
   static const taskSelection = 'disabled_tasks';
-  static const testMinDuration = 'test min duration';
-  static const testCooldownDuration = 'test cooldown duration';
-  static const testMinQueryCount = 'test min query count';
   static const crashlyticsEnabled = 'crashlyticsEnabled';
 }

--- a/flutter/lib/store.dart
+++ b/flutter/lib/store.dart
@@ -38,6 +38,7 @@ class Store extends ChangeNotifier {
   set selectedBenchmarkRunMode(BenchmarkRunModeEnum value) {
     _storeFromDisk.setString(
         StoreConstants.selectedBenchmarkRunMode, value.name);
+    cooldownDuration = value.cooldownDuration;
     notifyListeners();
   }
 
@@ -63,7 +64,7 @@ class Store extends ChangeNotifier {
     notifyListeners();
   }
 
-  int get cooldownDuration => _getInt(StoreConstants.cooldownDuration, 5);
+  int get cooldownDuration => _getInt(StoreConstants.cooldownDuration, 5 * 60);
 
   set cooldownDuration(int value) {
     _storeFromDisk.setInt(StoreConstants.cooldownDuration, value);

--- a/flutter/lib/ui/home/benchmark_running_screen.dart
+++ b/flutter/lib/ui/home/benchmark_running_screen.dart
@@ -69,7 +69,7 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
   Widget _title() {
     // The TaskRunner always run all benchmarks in performance mode first then in accuracy mode.
     var runModeStage = '1/1';
-    if (progress.runMode == BenchmarkRunModeEnum.submissionRun) {
+    if (progress.runMode.selectedRunModes.length > 1) {
       runModeStage = progress.accuracy ? '2/2' : '1/2';
     }
     var runModeName =

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -129,7 +129,11 @@ class _BenchmarkStartScreenState extends State<BenchmarkStartScreen> {
                       l10n.dialogContentMissingFiles);
               if (wrongPathError.isNotEmpty) {
                 if (!context.mounted) return;
-                await showErrorDialog(context, [wrongPathError]);
+                final messages = [
+                  wrongPathError,
+                  l10n.dialogContentMissingFilesHint
+                ];
+                await showErrorDialog(context, messages);
                 return;
               }
               if (store.offlineMode) {

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -75,8 +75,10 @@ class _ResourcesScreen extends State<ResourcesScreen> {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _downloadStatus(benchmark, BenchmarkRunMode.performance),
-            _downloadStatus(benchmark, BenchmarkRunMode.accuracy),
+            _downloadStatus(
+                benchmark, store.selectedBenchmarkRunMode.performanceRunMode),
+            _downloadStatus(
+                benchmark, store.selectedBenchmarkRunMode.accuracyRunMode),
           ],
         ),
       ),

--- a/flutter/lib/ui/settings/settings_screen.dart
+++ b/flutter/lib/ui/settings/settings_screen.dart
@@ -165,6 +165,7 @@ class _SettingsScreen extends State<SettingsScreen> {
           borderRadius: BorderRadius.circular(WidgetSizes.borderRadius),
           value: store.selectedBenchmarkRunMode,
           items: BenchmarkRunModeEnum.values
+              .where((e) => !e.isHiddenFromUI)
               .map((runMode) => DropdownMenuItem<BenchmarkRunModeEnum>(
                     value: runMode,
                     child: Text(runMode.localizedName(l10n)),

--- a/flutter/lib/ui/settings/settings_screen.dart
+++ b/flutter/lib/ui/settings/settings_screen.dart
@@ -92,9 +92,9 @@ class _SettingsScreen extends State<SettingsScreen> {
   Widget _cooldownSlider() {
     return Slider(
       value: store.cooldownDuration.toDouble(),
-      min: 1,
-      max: 10,
-      divisions: 9,
+      min: 0,
+      max: 10 * 60,
+      divisions: null,
       label: store.cooldownDuration.toString(),
       onChanged: store.cooldown
           ? (double value) {

--- a/flutter/unit_test/benchmark/benchmark_store_test.dart
+++ b/flutter/unit_test/benchmark/benchmark_store_test.dart
@@ -87,7 +87,7 @@ void main() {
         taskSelection: {task1.id: false},
       );
 
-      final modes = [BenchmarkRunMode.accuracy];
+      final modes = [BenchmarkRunModeEnum.performanceOnly.performanceRunMode];
       final activeBenchmarks =
           store.benchmarks.where((e) => e.isActive).toList();
       final resources = store.listResources(
@@ -104,7 +104,7 @@ void main() {
         taskSelection: {},
       );
 
-      final modes = [BenchmarkRunMode.accuracy];
+      final modes = [BenchmarkRunModeEnum.accuracyOnly.accuracyRunMode];
       final activeBenchmarks =
           store.benchmarks.where((e) => e.isActive).toList();
       final resources = store.listResources(
@@ -143,7 +143,7 @@ void main() {
         taskSelection: {},
       );
 
-      final modes = [BenchmarkRunMode.performance];
+      final modes = [BenchmarkRunModeEnum.performanceOnly.performanceRunMode];
       final activeBenchmarks =
           store.benchmarks.where((e) => e.isActive).toList();
       final resources = store.listResources(
@@ -176,8 +176,8 @@ void main() {
       );
 
       final modes = [
-        BenchmarkRunMode.accuracyTest,
-        BenchmarkRunMode.performanceTest,
+        BenchmarkRunModeEnum.integrationTestRun.accuracyRunMode,
+        BenchmarkRunModeEnum.integrationTestRun.performanceRunMode,
       ];
       final activeBenchmarks =
           store.benchmarks.where((e) => e.isActive).toList();


### PR DESCRIPTION
* Closes https://github.com/mlcommons/mobile_app_open/issues/932


<img src="https://github.com/user-attachments/assets/c5a9a8a1-8ef9-4345-b21b-dd7f1db6dd77" width="320">

- The "Integration Test Run" mode will be hidden from user. I just show it here for debug purpose.
- The cool down duration slider will be updated when the user change the run mode. But the duration can still be manually changed by the user.
- The other settings (min_query_count, min_duration, max_duration) are defined in the `tasks.pbtxt` file and cannot be changed by the user.


