### PR TITLE
Fix UI layouts

### DIFF
--- a/flutter/lib/resources/utils.dart
+++ b/flutter/lib/resources/utils.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:ui';
 
 import 'package:mlperfbench/resources/resource.dart';
 
@@ -22,4 +23,13 @@ List<String> filterInternetResources(List<Resource> resources) {
 String jsonToStringIndented(dynamic json) {
   const jsonEncoder = JsonEncoder.withIndent('  ');
   return jsonEncoder.convert(json);
+}
+
+/// Lineraly interpolates between [start] and [end] using a [factor] between [valueStart] and [ValueEnd] instead of between 0 and 1.
+double? lerpRange(
+    num? start, num? end, double valueStart, double valueEnd, double factor) {
+  final double valueEndNormalized = valueEnd - valueStart;
+  final double factorNormalized = (factor - valueStart) / valueEndNormalized;
+
+  return lerpDouble(start, end, factorNormalized);
 }

--- a/flutter/lib/ui/auto_size_text.dart
+++ b/flutter/lib/ui/auto_size_text.dart
@@ -1,0 +1,459 @@
+// Copyright (c) 2018 Simon Leier
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import 'package:flutter/widgets.dart';
+
+/// Flutter widget that automatically resizes text to fit perfectly within its
+/// bounds.
+///
+/// All size constraints as well as maxLines are taken into account. If the text
+/// overflows anyway, you should check if the parent widget actually constraints
+/// the size of this widget.
+
+// TODO(Farook): make the circle padding part completely optional for general use.
+class AutoSizeCircleText extends StatefulWidget {
+  /// Creates a [AutoSizeCircleText] widget.
+  ///
+  /// If the [style] argument is null, the text will use the style from the
+  /// closest enclosing [DefaultTextStyle].
+  const AutoSizeCircleText(
+    String this.data, {
+    Key? key,
+    this.textKey,
+    this.style,
+    this.strutStyle,
+    this.minFontSize = 12,
+    this.maxFontSize = double.infinity,
+    this.stepGranularity = 1,
+    this.presetFontSizes,
+    this.textAlign,
+    this.textDirection,
+    this.locale,
+    this.softWrap,
+    this.wrapWords = true,
+    this.overflow,
+    this.overflowReplacement,
+    this.textScaleFactor,
+    this.maxLines,
+    this.semanticsLabel,
+    this.circularPadding = 20,
+  })  : textSpan = null,
+        super(key: key);
+
+  /// Creates a [AutoSizeCircleText] widget with a [TextSpan].
+  const AutoSizeCircleText.rich(
+    TextSpan this.textSpan, {
+    Key? key,
+    this.textKey,
+    this.style,
+    this.strutStyle,
+    this.minFontSize = 12,
+    this.maxFontSize = double.infinity,
+    this.stepGranularity = 1,
+    this.presetFontSizes,
+    this.textAlign,
+    this.textDirection,
+    this.locale,
+    this.softWrap,
+    this.wrapWords = true,
+    this.overflow,
+    this.overflowReplacement,
+    this.textScaleFactor,
+    this.maxLines,
+    this.semanticsLabel,
+    this.circularPadding = 20,
+  })  : data = null,
+        super(key: key);
+
+  /// Sets the key for the resulting [Text] widget.
+  ///
+  /// This allows you to find the actual `Text` widget built by `AutoSizeText`.
+  final Key? textKey;
+
+  /// The text to display.
+  ///
+  /// This will be null if a [textSpan] is provided instead.
+  final String? data;
+
+  /// The text to display as a [TextSpan].
+  ///
+  /// This will be null if [data] is provided instead.
+  final TextSpan? textSpan;
+
+  /// If non-null, the style to use for this text.
+  ///
+  /// If the style's "inherit" property is true, the style will be merged with
+  /// the closest enclosing [DefaultTextStyle]. Otherwise, the style will
+  /// replace the closest enclosing [DefaultTextStyle].
+  final TextStyle? style;
+
+  // The default font size if none is specified.
+  static const double _defaultFontSize = 14;
+
+  /// The strut style to use. Strut style defines the strut, which sets minimum
+  /// vertical layout metrics.
+  ///
+  /// Omitting or providing null will disable strut.
+  ///
+  /// Omitting or providing null for any properties of [StrutStyle] will result
+  /// in default values being used. It is highly recommended to at least specify
+  /// a font size.
+  ///
+  /// See [StrutStyle] for details.
+  final StrutStyle? strutStyle;
+
+  /// The minimum text size constraint to be used when auto-sizing text.
+  ///
+  /// Is being ignored if [presetFontSizes] is set.
+  final double minFontSize;
+
+  /// The maximum text size constraint to be used when auto-sizing text.
+  ///
+  /// Is being ignored if [presetFontSizes] is set.
+  final double maxFontSize;
+
+  /// The step size in which the font size is being adapted to constraints.
+  ///
+  /// The Text scales uniformly in a range between [minFontSize] and
+  /// [maxFontSize].
+  /// Each increment occurs as per the step size set in stepGranularity.
+  ///
+  /// Most of the time you don't want a stepGranularity below 1.0.
+  ///
+  /// Is being ignored if [presetFontSizes] is set.
+  final double stepGranularity;
+
+  /// Predefines all the possible font sizes.
+  ///
+  /// **Important:** PresetFontSizes have to be in descending order.
+  final List<double>? presetFontSizes;
+
+  /// How the text should be aligned horizontally.
+  final TextAlign? textAlign;
+
+  /// The directionality of the text.
+  ///
+  /// This decides how [textAlign] values like [TextAlign.start] and
+  /// [TextAlign.end] are interpreted.
+  ///
+  /// This is also used to disambiguate how to render bidirectional text. For
+  /// example, if the [data] is an English phrase followed by a Hebrew phrase,
+  /// in a [TextDirection.ltr] context the English phrase will be on the left
+  /// and the Hebrew phrase to its right, while in a [TextDirection.rtl]
+  /// context, the English phrase will be on the right and the Hebrew phrase on
+  /// its left.
+  ///
+  /// Defaults to the ambient [Directionality], if any.
+  final TextDirection? textDirection;
+
+  /// Used to select a font when the same Unicode character can
+  /// be rendered differently, depending on the locale.
+  ///
+  /// It's rarely necessary to set this property. By default its value
+  /// is inherited from the enclosing app with `Localizations.localeOf(context)`.
+  final Locale? locale;
+
+  /// Whether the text should break at soft line breaks.
+  ///
+  /// If false, the glyphs in the text will be positioned as if there was
+  /// unlimited horizontal space.
+  final bool? softWrap;
+
+  /// Whether words which don't fit in one line should be wrapped.
+  ///
+  /// If false, the fontSize is lowered as far as possible until all words fit
+  /// into a single line.
+  final bool wrapWords;
+
+  /// How visual overflow should be handled.
+  ///
+  /// Defaults to retrieving the value from the nearest [DefaultTextStyle] ancestor.
+  final TextOverflow? overflow;
+
+  /// If the text is overflowing and does not fit its bounds, this widget is
+  /// displayed instead.
+  final Widget? overflowReplacement;
+
+  /// The number of font pixels for each logical pixel.
+  ///
+  /// For example, if the text scale factor is 1.5, text will be 50% larger than
+  /// the specified font size.
+  ///
+  /// This property also affects [minFontSize], [maxFontSize] and [presetFontSizes].
+  ///
+  /// The value given to the constructor as textScaleFactor. If null, will
+  /// use the [MediaQueryData.textScaleFactor] obtained from the ambient
+  /// [MediaQuery], or 1.0 if there is no [MediaQuery] in scope.
+  final double? textScaleFactor;
+
+  /// An optional maximum number of lines for the text to span, wrapping if necessary.
+  /// If the text exceeds the given number of lines, it will be resized according
+  /// to the specified bounds and if necessary truncated according to [overflow].
+  ///
+  /// If this is 1, text will not wrap. Otherwise, text will be wrapped at the
+  /// edge of the box.
+  ///
+  /// If this is null, but there is an ambient [DefaultTextStyle] that specifies
+  /// an explicit number for its [DefaultTextStyle.maxLines], then the
+  /// [DefaultTextStyle] value will take precedence. You can use a [RichText]
+  /// widget directly to entirely override the [DefaultTextStyle].
+  final int? maxLines;
+
+  /// An alternative semantics label for this text.
+  ///
+  /// If present, the semantics of this widget will contain this value instead
+  /// of the actual text. This will overwrite any of the semantics labels applied
+  /// directly to the [TextSpan]s.
+  ///
+  /// This is useful for replacing abbreviations or shorthands with the full
+  /// text value:
+  ///
+  /// ```dart
+  /// AutoSizeText(r'$$', semanticsLabel: 'Double dollars')
+  /// ```
+  final String? semanticsLabel;
+
+  final double circularPadding;
+
+  @override
+  _AutoSizeCircleTextState createState() => _AutoSizeCircleTextState();
+}
+
+class _AutoSizeCircleTextState extends State<AutoSizeCircleText> {
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, size) {
+      final defaultTextStyle = DefaultTextStyle.of(context);
+
+      var style = widget.style;
+      if (widget.style == null || widget.style!.inherit) {
+        style = defaultTextStyle.style.merge(widget.style);
+      }
+      if (style!.fontSize == null) {
+        style = style.copyWith(fontSize: AutoSizeCircleText._defaultFontSize);
+      }
+
+      final maxLines = widget.maxLines ?? defaultTextStyle.maxLines;
+
+      _validateProperties(style, maxLines);
+
+      final initialResult = _calculateFontSize(size, style, 1);
+      final fontSizeSingle = initialResult[0] as double;
+      final textFitsSingle = initialResult[1] as bool;
+
+      final result = _calculateFontSize(size, style, maxLines);
+      final fontSize = result[0] as double;
+      final textFits = result[1] as bool;
+
+      Widget text;
+
+      text = _buildText(
+          textFitsSingle ? fontSizeSingle : fontSize,
+          style,
+          maxLines,
+          textFitsSingle
+              ? const EdgeInsets.symmetric(horizontal: 20)
+              : EdgeInsets.symmetric(horizontal: widget.circularPadding));
+
+      if (widget.overflowReplacement != null && !textFits) {
+        return widget.overflowReplacement!;
+      } else {
+        return text;
+      }
+    });
+  }
+
+  void _validateProperties(TextStyle style, int? maxLines) {
+    assert(widget.overflow == null || widget.overflowReplacement == null,
+        'Either overflow or overflowReplacement must be null.');
+    assert(maxLines == null || maxLines > 0,
+        'MaxLines must be greater than or equal to 1.');
+    assert(widget.key == null || widget.key != widget.textKey,
+        'Key and textKey must not be equal.');
+
+    if (widget.presetFontSizes == null) {
+      assert(
+          widget.stepGranularity >= 0.1,
+          'StepGranularity must be greater than or equal to 0.1. It is not a '
+          'good idea to resize the font with a higher accuracy.');
+      assert(widget.minFontSize >= 0,
+          'MinFontSize must be greater than or equal to 0.');
+      assert(widget.maxFontSize > 0, 'MaxFontSize has to be greater than 0.');
+      assert(widget.minFontSize <= widget.maxFontSize,
+          'MinFontSize must be smaller or equal than maxFontSize.');
+      assert(widget.minFontSize / widget.stepGranularity % 1 == 0,
+          'MinFontSize must be a multiple of stepGranularity.');
+      if (widget.maxFontSize != double.infinity) {
+        assert(widget.maxFontSize / widget.stepGranularity % 1 == 0,
+            'MaxFontSize must be a multiple of stepGranularity.');
+      }
+    } else {
+      assert(widget.presetFontSizes!.isNotEmpty,
+          'PresetFontSizes must not be empty.');
+    }
+  }
+
+  List _calculateFontSize(
+      BoxConstraints size, TextStyle? style, int? maxLines) {
+    final span = TextSpan(
+      style: widget.textSpan?.style ?? style,
+      text: widget.textSpan?.text ?? widget.data,
+      children: widget.textSpan?.children,
+      recognizer: widget.textSpan?.recognizer,
+    );
+
+    final userScale =
+        widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
+
+    int left;
+    int right;
+
+    final presetFontSizes = widget.presetFontSizes?.reversed.toList();
+    if (presetFontSizes == null) {
+      final num defaultFontSize =
+          style!.fontSize!.clamp(widget.minFontSize, widget.maxFontSize);
+      final defaultScale = defaultFontSize * userScale / style.fontSize!;
+      if (_checkTextFits(span, defaultScale, maxLines, size)) {
+        return <Object>[defaultFontSize * userScale, true];
+      }
+
+      left = (widget.minFontSize / widget.stepGranularity).floor();
+      right = (defaultFontSize / widget.stepGranularity).ceil();
+    } else {
+      left = 0;
+      right = presetFontSizes.length - 1;
+    }
+
+    var lastValueFits = false;
+    while (left <= right) {
+      final mid = (left + (right - left) / 2).floor();
+      double scale;
+      if (presetFontSizes == null) {
+        scale = mid * userScale * widget.stepGranularity / style!.fontSize!;
+      } else {
+        scale = presetFontSizes[mid] * userScale / style!.fontSize!;
+      }
+      if (_checkTextFits(span, scale, maxLines, size)) {
+        left = mid + 1;
+        lastValueFits = true;
+      } else {
+        right = mid - 1;
+      }
+    }
+
+    if (!lastValueFits) {
+      right += 1;
+    }
+
+    double fontSize;
+    if (presetFontSizes == null) {
+      fontSize = right * userScale * widget.stepGranularity;
+    } else {
+      fontSize = presetFontSizes[right] * userScale;
+    }
+
+    return <Object>[fontSize, lastValueFits];
+  }
+
+  bool _checkTextFits(
+      TextSpan text, double scale, int? maxLines, BoxConstraints constraints) {
+    if (!widget.wrapWords) {
+      final words = text.toPlainText().split(RegExp('\\s+'));
+
+      final wordWrapTextPainter = TextPainter(
+        text: TextSpan(
+          style: text.style,
+          text: words.join('\n'),
+        ),
+        textAlign: widget.textAlign ?? TextAlign.left,
+        textDirection: widget.textDirection ?? TextDirection.ltr,
+        textScaleFactor: scale,
+        maxLines: words.length,
+        locale: widget.locale,
+        strutStyle: widget.strutStyle,
+      );
+
+      wordWrapTextPainter.layout(maxWidth: constraints.maxWidth);
+
+      if (wordWrapTextPainter.didExceedMaxLines ||
+          wordWrapTextPainter.width > constraints.maxWidth) {
+        return false;
+      }
+    }
+
+    final textPainter = TextPainter(
+      text: text,
+      textAlign: widget.textAlign ?? TextAlign.left,
+      textDirection: widget.textDirection ?? TextDirection.ltr,
+      textScaleFactor: scale,
+      maxLines: maxLines,
+      locale: widget.locale,
+      strutStyle: widget.strutStyle,
+    );
+
+    textPainter.layout(maxWidth: constraints.maxWidth);
+
+    return !(textPainter.didExceedMaxLines ||
+        textPainter.height > constraints.maxHeight ||
+        textPainter.width > constraints.maxWidth);
+  }
+
+  Widget _buildText(
+      double fontSize, TextStyle style, int? maxLines, EdgeInsets padding) {
+    if (widget.data != null) {
+      return Padding(
+        padding: padding,
+        child: Text(
+          widget.data!,
+          key: widget.textKey,
+          style: style.copyWith(fontSize: fontSize),
+          strutStyle: widget.strutStyle,
+          textAlign: widget.textAlign,
+          textDirection: widget.textDirection,
+          locale: widget.locale,
+          softWrap: widget.softWrap,
+          overflow: widget.overflow,
+          textScaleFactor: 1,
+          maxLines: maxLines,
+          semanticsLabel: widget.semanticsLabel,
+        ),
+      );
+    } else {
+      return Text.rich(
+        widget.textSpan!,
+        key: widget.textKey,
+        style: style,
+        strutStyle: widget.strutStyle,
+        textAlign: widget.textAlign,
+        textDirection: widget.textDirection,
+        locale: widget.locale,
+        softWrap: widget.softWrap,
+        overflow: widget.overflow,
+        textScaleFactor: fontSize / style.fontSize!,
+        maxLines: maxLines,
+        semanticsLabel: widget.semanticsLabel,
+      );
+    }
+  }
+
+  void _notifySync() {
+    setState(() {});
+  }
+}

--- a/flutter/lib/ui/auto_size_text.dart
+++ b/flutter/lib/ui/auto_size_text.dart
@@ -254,6 +254,8 @@ class _AutoSizeCircleTextState extends State<AutoSizeCircleText> {
 
       _validateProperties(style, maxLines);
 
+      size = size.copyWith(maxWidth: size.maxWidth-20);
+
       final initialResult = _calculateFontSize(size, style, 1);
       final fontSizeSingle = initialResult[0] as double;
       final textFitsSingle = initialResult[1] as bool;
@@ -267,9 +269,9 @@ class _AutoSizeCircleTextState extends State<AutoSizeCircleText> {
       text = _buildText(
           textFitsSingle ? fontSizeSingle : fontSize,
           style,
-          maxLines,
+          textFitsSingle ? 1 : maxLines,
           textFitsSingle
-              ? const EdgeInsets.symmetric(horizontal: 20)
+              ? const EdgeInsets.symmetric(horizontal: 10)
               : EdgeInsets.symmetric(horizontal: widget.circularPadding));
 
       if (widget.overflowReplacement != null && !textFits) {

--- a/flutter/lib/ui/home/app_drawer.dart
+++ b/flutter/lib/ui/home/app_drawer.dart
@@ -41,8 +41,11 @@ class AppDrawer extends StatelessWidget {
         child: Container(
           color: AppColors.drawerBackground,
           child: SafeArea(
-            child: Column(
-              children: [header] + menuList,
+            child: ScrollConfiguration(
+              behavior: NoGlowScrollBehavior(),
+              child: ListView(
+                children: [header] + menuList,
+              ),
             ),
           ),
         ),
@@ -141,5 +144,14 @@ class AppDrawer extends StatelessWidget {
         onTap: () => launchUrl(Uri.parse(Url.eula)),
       ),
     ];
+  }
+}
+
+// Custom ScrollBehavior
+class NoGlowScrollBehavior extends ScrollBehavior {
+  @override
+  Widget buildOverscrollIndicator(
+      BuildContext context, Widget child, ScrollableDetails details) {
+    return child; // Disable glow effect
   }
 }

--- a/flutter/lib/ui/home/benchmark_config_section.dart
+++ b/flutter/lib/ui/home/benchmark_config_section.dart
@@ -7,6 +7,7 @@ import 'package:mlperfbench/benchmark/benchmark.dart';
 import 'package:mlperfbench/benchmark/state.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/ui/app_styles.dart';
+import 'package:mlperfbench/ui/nil.dart';
 import 'package:mlperfbench/ui/home/benchmark_info_button.dart';
 
 class BenchmarkConfigSection extends StatefulWidget {
@@ -121,10 +122,10 @@ class _BenchmarkConfigSectionState extends State<BenchmarkConfigSection> {
         .map((e) => e.delegateName)
         .toList();
     if (choices.isEmpty) {
-      return const SizedBox();
+      return nil;
     }
     if (choices.length == 1 && choices.first.isEmpty) {
-      return const SizedBox();
+      return nil;
     }
     if (!choices.contains(selected)) {
       throw 'delegate_selected=$selected must be one of delegate_choice=$choices';
@@ -133,7 +134,7 @@ class _BenchmarkConfigSectionState extends State<BenchmarkConfigSection> {
       isExpanded: true,
       isDense: false,
       borderRadius: BorderRadius.circular(WidgetSizes.borderRadius),
-      underline: const SizedBox(),
+      underline: nil,
       value: selected,
       items: choices
           .map((item) => DropdownMenuItem<String>(

--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -12,6 +12,7 @@ import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/ui/app_styles.dart';
 import 'package:mlperfbench/ui/confirm_dialog.dart';
 import 'package:mlperfbench/ui/formatter.dart';
+import 'package:mlperfbench/ui/nil.dart';
 import 'package:mlperfbench/ui/home/app_drawer.dart';
 import 'package:mlperfbench/ui/home/benchmark_info_button.dart';
 import 'package:mlperfbench/ui/home/result_circle.dart';
@@ -74,27 +75,27 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
-        bottom: PreferredSize(
-          preferredSize: const Size.fromHeight(56.0),
-          child: _shareSection(),
-        ),
         backgroundColor: AppColors.secondaryAppBarBackground,
       ),
       drawer: const AppDrawer(),
-      body: LayoutBuilder(
-        builder: (context, constraint) {
-          return SingleChildScrollView(
-            physics: const ClampingScrollPhysics(),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                _totalScoreSection(),
-                const SizedBox(height: 20),
-                _detailSection(),
-              ],
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _shareSection(),
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const ClampingScrollPhysics(),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  _totalScoreSection(),
+                  const SizedBox(height: 20),
+                  _detailSection(),
+                ],
+              ),
             ),
-          );
-        },
+          ),
+        ],
       ),
     );
   }
@@ -120,7 +121,7 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
         style: const TextStyle(color: AppColors.resultInvalidText),
       );
       runModeString = l10n.unknown;
-      shareButton = const SizedBox();
+      shareButton = nil;
       shareButtonFlex = 0;
     }
 

--- a/flutter/lib/ui/home/benchmark_running_screen.dart
+++ b/flutter/lib/ui/home/benchmark_running_screen.dart
@@ -16,6 +16,7 @@ import 'package:mlperfbench/ui/app_styles.dart';
 import 'package:mlperfbench/ui/formatter.dart';
 import 'package:mlperfbench/ui/home/progress_circle.dart';
 import 'package:mlperfbench/ui/icons.dart';
+import 'package:mlperfbench/ui/auto_size_text.dart';
 
 class BenchmarkRunningScreen extends StatefulWidget {
   static final GlobalKey<ScaffoldState> scaffoldKey =
@@ -56,13 +57,13 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
-            Expanded(flex: 18, child: _title()),
+            _title(),
             const SizedBox(height: 20),
-            Expanded(flex: 28, child: _circle()),
+            _circle(),
             const SizedBox(height: 20),
-            Expanded(flex: 40, child: _taskList()),
+            Expanded(child: _taskList()),
             const SizedBox(height: 20),
-            Expanded(flex: 14, child: _footer()),
+            _footer(),
           ],
         ),
       ),
@@ -109,51 +110,62 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
     var containerWidth = 0.50 * MediaQuery.of(context).size.width;
     containerWidth = max(containerWidth, 160);
     containerWidth = min(containerWidth, 240);
-    return Stack(
-      alignment: AlignmentDirectional.center,
-      children: <Widget>[
-        Container(
-          width: containerWidth,
-          height: containerWidth,
-          decoration: const BoxDecoration(
-            shape: BoxShape.circle,
-            color: AppColors.progressCircle,
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black12,
-                offset: Offset(15, 15),
-                blurRadius: 10,
-              )
-            ],
-          ),
-          child: ClipOval(
-            child: Padding(
-              padding: const EdgeInsets.all(4),
-              child: _circleContent(),
+    return SizedBox(
+      width: containerWidth,
+      height: containerWidth,
+      child: Stack(
+        alignment: AlignmentDirectional.center,
+        children: <Widget>[
+          Container(
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: AppColors.progressCircle,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black12,
+                  offset: Offset(15, 15),
+                  blurRadius: 10,
+                )
+              ],
+            ),
+            child: ClipOval(
+              child: Padding(
+                padding: const EdgeInsets.all(4),
+                child: _circleContent(containerWidth),
+              ),
             ),
           ),
-        ),
-        ProgressCircle(
-          strokeWidth: 6,
-          size: containerWidth + 20,
-        ),
-      ],
+          ProgressCircle(
+            strokeWidth: 6,
+            size: containerWidth + 20,
+          ),
+        ],
+      ),
     );
   }
 
-  Widget _circleContent() {
+  Widget _circleContent(double containerWidth) {
     Widget? topWidget;
     String taskNameString;
+
+    final double containerRadius = containerWidth / 2;
+    final double creepFactor =
+        2 + ((containerWidth - 160) / 20); // lerp 2-6 at 160-240
+    final double horizontalPadding = containerRadius -
+        sqrt(pow(containerRadius, 2) -
+            pow((containerRadius - (8 * creepFactor)), 2));
+
     const textStyle = TextStyle(
       fontSize: 14,
       fontWeight: FontWeight.w500,
       color: AppColors.lightText,
     );
     if (progress.cooldown) {
-      topWidget = Text(
+      topWidget = AutoSizeCircleText(
         l10n.progressCooldown,
         textAlign: TextAlign.center,
         style: textStyle,
+        circularPadding: horizontalPadding,
       );
       taskNameString = l10n.progressRemainingTime;
     } else {
@@ -173,7 +185,7 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
           flex: 3,
           child: Container(
             alignment: Alignment.bottomCenter,
-            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 40),
+            padding: const EdgeInsets.symmetric(vertical: 4),
             child: topWidget,
           ),
         ),
@@ -188,11 +200,14 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
           flex: 3,
           child: Container(
             alignment: Alignment.topCenter,
-            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 20),
-            child: Text(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: AutoSizeCircleText(
               taskNameString,
               textAlign: TextAlign.center,
               style: textStyle,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              circularPadding: horizontalPadding,
             ),
           ),
         ),
@@ -269,9 +284,9 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
       return Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          const Spacer(),
-          Expanded(flex: 2, child: _footerText()),
+          _footerText(),
           _cancelButton(),
         ],
       );
@@ -397,6 +412,7 @@ class _StageProgressTextState extends State<_StageProgressText> {
       progressStr,
       style: const TextStyle(
         fontSize: 54,
+        height: 1.0,
         fontWeight: FontWeight.bold,
         color: AppColors.lightText,
       ),

--- a/flutter/lib/ui/home/benchmark_running_screen.dart
+++ b/flutter/lib/ui/home/benchmark_running_screen.dart
@@ -12,11 +12,13 @@ import 'package:mlperfbench/benchmark/state.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/state/task_runner.dart';
 import 'package:mlperfbench/store.dart';
+import 'package:mlperfbench/protos/mlperf_task.pb.dart';
 import 'package:mlperfbench/ui/app_styles.dart';
 import 'package:mlperfbench/ui/formatter.dart';
 import 'package:mlperfbench/ui/home/progress_circle.dart';
 import 'package:mlperfbench/ui/icons.dart';
 import 'package:mlperfbench/ui/auto_size_text.dart';
+import 'package:mlperfbench/resources/utils.dart';
 
 class BenchmarkRunningScreen extends StatefulWidget {
   static final GlobalKey<ScaffoldState> scaffoldKey =
@@ -107,12 +109,11 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
   }
 
   Widget _circle() {
-    var containerWidth = 0.50 * MediaQuery.of(context).size.width;
-    containerWidth = max(containerWidth, 160);
-    containerWidth = min(containerWidth, 240);
+    var diameter = 0.50 * MediaQuery.of(context).size.width;
+    diameter = diameter.clamp(160.0, 240.0);
     return SizedBox(
-      width: containerWidth,
-      height: containerWidth,
+      width: diameter,
+      height: diameter,
       child: Stack(
         alignment: AlignmentDirectional.center,
         children: <Widget>[
@@ -131,29 +132,29 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
             child: ClipOval(
               child: Padding(
                 padding: const EdgeInsets.all(4),
-                child: _circleContent(containerWidth),
+                child: _circleContent(diameter),
               ),
             ),
           ),
           ProgressCircle(
             strokeWidth: 6,
-            size: containerWidth + 20,
+            size: diameter + 20,
           ),
         ],
       ),
     );
   }
 
-  Widget _circleContent(double containerWidth) {
+  Widget _circleContent(double diameter) {
     Widget? topWidget;
     String taskNameString;
 
-    final double containerRadius = containerWidth / 2;
-    final double creepFactor =
-        2 + ((containerWidth - 160) / 20); // lerp 2-6 at 160-240
+    final double containerRadius = diameter / 2;
+    final double creepFactor = lerpRange(2, 6, 160, 240, diameter)!;
     final double horizontalPadding = containerRadius -
         sqrt(pow(containerRadius, 2) -
-            pow((containerRadius - (8 * creepFactor)), 2));
+            pow((containerRadius - (8 * creepFactor)),
+                2)); // 8 is the padding from the bottom of the circle to the bottom of the text
 
     const textStyle = TextStyle(
       fontSize: 14,

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -41,22 +41,12 @@ class _BenchmarkStartScreenState extends State<BenchmarkStartScreen> {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
+          _goButtonSection(context),
+          _infoSection(),
           Expanded(
-            flex: 34,
-            child: _goButtonSection(context),
-          ),
-          Expanded(
-            flex: 6,
-            child: _infoSection(),
-          ),
-          Expanded(
-            flex: 60,
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: AbsorbPointer(
-                absorbing: state.state != BenchmarkStateEnum.waiting,
-                child: const BenchmarkConfigSection(),
-              ),
+            child: AbsorbPointer(
+              absorbing: state.state != BenchmarkStateEnum.waiting,
+              child: const BenchmarkConfigSection(),
             ),
           )
         ],
@@ -81,10 +71,8 @@ class _BenchmarkStartScreenState extends State<BenchmarkStartScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Expanded(flex: 1, child: Text(deviceDescription)),
-            Expanded(flex: 1, child: Text(selectedBenchmarkText))
-          ],
+          mainAxisSize: MainAxisSize.min,
+          children: [Text(deviceDescription), Text(selectedBenchmarkText)],
         ),
       ),
     );
@@ -93,89 +81,94 @@ class _BenchmarkStartScreenState extends State<BenchmarkStartScreen> {
   Widget _goButtonSection(BuildContext context) {
     final circleWidth =
         MediaQuery.of(context).size.width * WidgetSizes.circleWidthFactor;
+    const double verticalPadding = 8.0;
+    final sectionHeight = circleWidth + verticalPadding * 2.0;
 
-    return Stack(
-      alignment: Alignment.topCenter,
-      children: [
-        Container(
-          width: MediaQuery.of(context).size.width,
-          alignment: Alignment.center,
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: AppGradients.halfScreen,
-            ),
-          ),
-        ),
-        Container(
-          alignment: Alignment.center,
-          child: ElevatedButton(
-            key: const Key(WidgetKeys.goButton),
-            style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.goCircle,
-                shape: const CircleBorder(),
-                minimumSize: Size.fromWidth(circleWidth)),
-            child: Text(
-              l10n.mainScreenGo,
-              style: const TextStyle(
-                color: AppColors.lightText,
-                fontSize: 40,
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      height: sectionHeight,
+      child: Stack(
+        alignment: Alignment.topCenter,
+        children: [
+          Container(
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: AppGradients.halfScreen,
               ),
             ),
-            onPressed: () async {
-              final wrongPathError = await state.validator
-                  .validateExternalResourcesDirectory(
-                      l10n.dialogContentMissingFiles);
-              if (wrongPathError.isNotEmpty) {
-                if (!context.mounted) return;
-                final messages = [
-                  wrongPathError,
-                  l10n.dialogContentMissingFilesHint
-                ];
-                await showErrorDialog(context, messages);
-                return;
-              }
-              if (store.offlineMode) {
-                final offlineError = await state.validator
-                    .validateOfflineMode(l10n.dialogContentOfflineWarning);
-                if (offlineError.isNotEmpty) {
+          ),
+          Container(
+            alignment: Alignment.center,
+            child: ElevatedButton(
+              key: const Key(WidgetKeys.goButton),
+              style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.goCircle,
+                  shape: const CircleBorder(),
+                  minimumSize: Size.fromWidth(circleWidth)),
+              child: Text(
+                l10n.mainScreenGo,
+                style: const TextStyle(
+                  color: AppColors.lightText,
+                  fontSize: 40,
+                ),
+              ),
+              onPressed: () async {
+                final wrongPathError = await state.validator
+                    .validateExternalResourcesDirectory(
+                        l10n.dialogContentMissingFiles);
+                if (wrongPathError.isNotEmpty) {
                   if (!context.mounted) return;
-                  switch (await showConfirmDialog(context, offlineError)) {
-                    case ConfirmDialogAction.ok:
-                      break;
-                    case ConfirmDialogAction.cancel:
-                      return;
-                    default:
-                      break;
+                  final messages = [
+                    wrongPathError,
+                    l10n.dialogContentMissingFilesHint
+                  ];
+                  await showErrorDialog(context, messages);
+                  return;
+                }
+                if (store.offlineMode) {
+                  final offlineError = await state.validator
+                      .validateOfflineMode(l10n.dialogContentOfflineWarning);
+                  if (offlineError.isNotEmpty) {
+                    if (!context.mounted) return;
+                    switch (await showConfirmDialog(context, offlineError)) {
+                      case ConfirmDialogAction.ok:
+                        break;
+                      case ConfirmDialogAction.cancel:
+                        return;
+                      default:
+                        break;
+                    }
                   }
                 }
-              }
-              final selectedCount =
-                  state.benchmarks.where((e) => e.isActive).length;
-              if (selectedCount < 1) {
-                // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
-                // ignore: use_build_context_synchronously
-                if (!context.mounted) return;
-                await showErrorDialog(
-                    context, [l10n.dialogContentNoSelectedBenchmarkError]);
-                return;
-              }
-              try {
-                await state.runBenchmarks();
-              } catch (e, t) {
-                print(t);
-                // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
-                // ignore: use_build_context_synchronously
-                if (!context.mounted) return;
-                await showErrorDialog(
-                    context, ['${l10n.runFail}:', e.toString()]);
-                return;
-              }
-            },
+                final selectedCount =
+                    state.benchmarks.where((e) => e.isActive).length;
+                if (selectedCount < 1) {
+                  // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
+                  // ignore: use_build_context_synchronously
+                  if (!context.mounted) return;
+                  await showErrorDialog(
+                      context, [l10n.dialogContentNoSelectedBenchmarkError]);
+                  return;
+                }
+                try {
+                  await state.runBenchmarks();
+                } catch (e, t) {
+                  print(t);
+                  // Workaround for Dart linter bug. See https://github.com/dart-lang/linter/issues/4007
+                  // ignore: use_build_context_synchronously
+                  if (!context.mounted) return;
+                  await showErrorDialog(
+                      context, ['${l10n.runFail}:', e.toString()]);
+                  return;
+                }
+              },
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/flutter/lib/ui/nil.dart
+++ b/flutter/lib/ui/nil.dart
@@ -1,0 +1,59 @@
+// MIT License
+
+// Copyright (c) 2021 Romain Rastel
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
+
+/// A [Nil] instance, you can use in your layouts.
+const nil = Nil();
+
+/// A widget which is not in the layout and does nothing.
+/// It is useful when you have to return a widget and can't return null.
+class Nil extends Widget {
+  /// Creates a [Nil] widget.
+  const Nil({Key? key}) : super(key: key);
+
+  @override
+  Element createElement() => _NilElement(this);
+}
+
+class _NilElement extends Element {
+  _NilElement(Nil widget) : super(widget);
+
+  @override
+  void mount(Element? parent, dynamic newSlot) {
+    assert(parent is! MultiChildRenderObjectElement, """
+        You are using Nil under a MultiChildRenderObjectElement.
+        This suggests a possibility that the Nil is not needed or is being used improperly.
+        Make sure it can't be replaced with an inline conditional or
+        omission of the target widget from a list.
+        """);
+
+    super.mount(parent, newSlot);
+  }
+
+  @override
+  bool get debugDoingBuild => false;
+
+  @override
+  void performRebuild() {}
+}

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -9,6 +9,7 @@ import 'package:mlperfbench/benchmark/state.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/store.dart';
 import 'package:mlperfbench/ui/confirm_dialog.dart';
+import 'package:mlperfbench/ui/nil.dart';
 
 class ResourcesScreen extends StatefulWidget {
   const ResourcesScreen({super.key});
@@ -136,32 +137,29 @@ class _ResourcesScreen extends State<ResourcesScreen> {
 
   Widget _downloadProgress() {
     if (!downloading) {
-      return const SizedBox(height: 0);
+      return nil;
     }
-    return SizedBox(
-      height: 88,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            l10n.resourceDownloading,
-            maxLines: 1,
-            style: const TextStyle(fontSize: 12),
-          ),
-          Text(
-            state.loadingPath,
-            maxLines: 5,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(fontSize: 12),
-          ),
-          const SizedBox(height: 8),
-          LinearProgressIndicator(
-            value: state.loadingProgress,
-            minHeight: 8,
-          ),
-        ],
-      ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.resourceDownloading,
+          maxLines: 1,
+          style: const TextStyle(fontSize: 12),
+        ),
+        Text(
+          state.loadingPath,
+          maxLines: 5,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 12),
+        ),
+        const SizedBox(height: 8),
+        LinearProgressIndicator(
+          value: state.loadingProgress,
+          minHeight: 8,
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
This PR fixes #942 by making sure the app does not clip or overlap elements on extreme screen sizes.

The primary culprit behind the clipping was the many Expanded elements, those were simplified and only the variable size items (such as lists) were allowed to expand.