### PR TITLE
Add Offline Dialog

### DIFF
--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -94,6 +94,7 @@
   "dialogContentMissingFilesHint": "Please go to the menu Resources to download the missing files.",
   "dialogContentChecksumError": "The following files failed checksum validation:",
   "dialogContentNoSelectedBenchmarkError": "Please select at least one benchmark.",
+  "dialogNoInternetError": "A network error has occured. Please make sure you're connected to the internet.",
 
 
   "benchModePerformanceOnly": "Performance Only",

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:bot_toast/bot_toast.dart';
@@ -9,6 +11,7 @@ import 'package:mlperfbench/benchmark/state.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/store.dart';
 import 'package:mlperfbench/ui/confirm_dialog.dart';
+import 'package:mlperfbench/ui/error_dialog.dart';
 
 class ResourcesScreen extends StatefulWidget {
   const ResourcesScreen({super.key});
@@ -169,8 +172,14 @@ class _ResourcesScreen extends State<ResourcesScreen> {
     return AbsorbPointer(
       absorbing: downloading,
       child: ElevatedButton(
-        onPressed: () {
-          state.loadResources(downloadMissing: true);
+        onPressed: () async {
+          try {
+            await state.loadResources(downloadMissing: true);
+          } on SocketException {
+            await state.clearCache();
+            if (!context.mounted) return;
+            await showErrorDialog(context, <String>[l10n.dialogNoInternetError]);
+          }
         },
         style: ElevatedButton.styleFrom(
             backgroundColor: downloading ? Colors.grey : Colors.blue),


### PR DESCRIPTION
Added Dialog for when an offline (not connected to the internet) user attempts to download resources, the error only occurs in case a `SocketException` is caught, any other exceptions are still unhandled.

This fixes #948

![Screenshot_1737473522](https://github.com/user-attachments/assets/50e9f6a3-8e46-4c74-8aa4-6baaf3d6b926)