### PR TITLE
Add offline dialog

### DIFF
--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -143,15 +143,21 @@ class BenchmarkState extends ChangeNotifier {
       modes: [taskRunner.perfMode, taskRunner.accuracyMode],
       benchmarks: benchmarks,
     );
-    await resourceManager.handleResources(
-      resources,
-      needToPurgeCache,
-      downloadMissing,
-    );
-    print('Finished loading resources with downloadMissing=$downloadMissing');
-    error = null;
-    stackTrace = null;
-    taskConfigFailedToLoad = false;
+    try {
+      await resourceManager.handleResources(
+        resources,
+        needToPurgeCache,
+        downloadMissing,
+      );
+      print('Finished loading resources with downloadMissing=$downloadMissing');
+      error = null;
+      stackTrace = null;
+      taskConfigFailedToLoad = false;
+    } on SocketException catch (e, s) {
+      print('Could not load resources due to error: $e');
+      error = e;
+      stackTrace = s;
+    }
     await Wakelock.disable();
   }
 

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -153,7 +153,7 @@ class BenchmarkState extends ChangeNotifier {
       error = null;
       stackTrace = null;
       taskConfigFailedToLoad = false;
-    } on SocketException catch (e, s) {
+    } catch (e, s) {
       print('Could not load resources due to error: $e');
       error = e;
       stackTrace = s;

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -94,6 +94,7 @@
   "dialogContentMissingFilesHint": "Please go to the menu Resources to download the missing files.",
   "dialogContentChecksumError": "The following files failed checksum validation:",
   "dialogContentNoSelectedBenchmarkError": "Please select at least one benchmark.",
+  "dialogNoInternetError": "A network error has occured. Please make sure you're connected to the internet.",
 
 
   "benchModePerformanceOnly": "Performance Only",

--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -94,8 +94,6 @@
   "dialogContentMissingFilesHint": "Please go to the menu Resources to download the missing files.",
   "dialogContentChecksumError": "The following files failed checksum validation:",
   "dialogContentNoSelectedBenchmarkError": "Please select at least one benchmark.",
-  "dialogNoInternetError": "A network error has occured. Please make sure you're connected to the internet.",
-
 
   "benchModePerformanceOnly": "Performance Only",
   "benchModeAccuracyOnly": "Accuracy Only",

--- a/flutter/lib/resources/resource_manager.dart
+++ b/flutter/lib/resources/resource_manager.dart
@@ -135,7 +135,7 @@ class ResourceManager {
 
       // delete downloaded archives to free up disk space
       await cacheManager.deleteArchives(internetPaths);
-    }  finally {
+    } finally {
       _loadingPath = '';
       _loadingProgress = 1.0;
       _done = true;

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -173,13 +173,11 @@ class _ResourcesScreen extends State<ResourcesScreen> {
         onPressed: () async {
           await state.loadResources(downloadMissing: true);
           if (state.error != null) {
+            if (!mounted) return;
+            await showErrorDialog(context, <String>[state.error.toString()]);
             // Reset both the error and stacktrace for further operation
             state.error = null;
             state.stackTrace = null;
-
-            if (!mounted) return;
-            await showErrorDialog(
-                context, <String>[l10n.dialogNoInternetError]);
           }
         },
         style: ElevatedButton.styleFrom(

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -178,7 +178,8 @@ class _ResourcesScreen extends State<ResourcesScreen> {
           } on SocketException {
             await state.clearCache();
             if (!context.mounted) return;
-            await showErrorDialog(context, <String>[l10n.dialogNoInternetError]);
+            await showErrorDialog(
+                context, <String>[l10n.dialogNoInternetError]);
           }
         },
         style: ElevatedButton.styleFrom(

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 
 import 'package:bot_toast/bot_toast.dart';

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:bot_toast/bot_toast.dart';
@@ -9,6 +11,7 @@ import 'package:mlperfbench/benchmark/state.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
 import 'package:mlperfbench/store.dart';
 import 'package:mlperfbench/ui/confirm_dialog.dart';
+import 'package:mlperfbench/ui/error_dialog.dart';
 
 class ResourcesScreen extends StatefulWidget {
   const ResourcesScreen({super.key});
@@ -169,8 +172,14 @@ class _ResourcesScreen extends State<ResourcesScreen> {
     return AbsorbPointer(
       absorbing: downloading,
       child: ElevatedButton(
-        onPressed: () {
-          state.loadResources(downloadMissing: true);
+        onPressed: () async {
+          try {
+            await state.loadResources(downloadMissing: true);
+          } on SocketException {
+            await state.clearCache();
+            if (!context.mounted) return;
+            await showErrorDialog(context, <String>[l10n.dialogNoInternetError]);
+          }
         },
         style: ElevatedButton.styleFrom(
             backgroundColor: downloading ? Colors.grey : Colors.blue),

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -177,7 +177,7 @@ class _ResourcesScreen extends State<ResourcesScreen> {
             await state.loadResources(downloadMissing: true);
           } on SocketException {
             await state.clearCache();
-            if (!context.mounted) return;
+            if (!mounted) return;
             await showErrorDialog(
                 context, <String>[l10n.dialogNoInternetError]);
           }

--- a/flutter/lib/ui/settings/resources_screen.dart
+++ b/flutter/lib/ui/settings/resources_screen.dart
@@ -173,10 +173,12 @@ class _ResourcesScreen extends State<ResourcesScreen> {
       absorbing: downloading,
       child: ElevatedButton(
         onPressed: () async {
-          try {
-            await state.loadResources(downloadMissing: true);
-          } on SocketException {
-            await state.clearCache();
+          await state.loadResources(downloadMissing: true);
+          if (state.error != null) {
+            // Reset both the error and stacktrace for further operation
+            state.error = null;
+            state.stackTrace = null;
+
             if (!mounted) return;
             await showErrorDialog(
                 context, <String>[l10n.dialogNoInternetError]);


### PR DESCRIPTION
Added Dialog for when an offline (not connected to the internet) user attempts to download resources, the error only occurs in case a SocketException is caught, any other exceptions are still unhandled.

This fixes #948

![image](https://github.com/user-attachments/assets/5562b135-755b-48ba-9b5c-cb1f60f7d735)
