### PR TITLE
chore: delete resources that failed checksum validation

### DIFF
--- a/flutter/lib/resources/cache_manager.dart
+++ b/flutter/lib/resources/cache_manager.dart
@@ -73,6 +73,16 @@ class CacheManager {
     }
   }
 
+  Future<void> deleteFiles(List<String> resources) async {
+    for (final resource in resources) {
+      final filePath = get(resource);
+      if (filePath == null) continue;
+      final file = File(filePath);
+      if (await file.exists()) await file.delete();
+      print('Deleted resource $resource stored at ${file.path}');
+    }
+  }
+
   Future<void> purgeOutdatedCache(int atLeastDaysOld) async {
     var currentResources = <String>[];
     for (var r in _resourcesMap.values) {

--- a/flutter/lib/resources/resource_manager.dart
+++ b/flutter/lib/resources/resource_manager.dart
@@ -129,8 +129,11 @@ class ResourceManager {
 
       final checksumFailed = await validateResourcesChecksum(resources);
       if (checksumFailed.isNotEmpty) {
-        final mismatchedPaths = checksumFailed.map((e) => '\n${e.path}').join();
-        throw 'Checksum validation failed for: $mismatchedPaths';
+        final checksumFailedPathString =
+            checksumFailed.map((e) => '\n${e.path}').join();
+        final checksumFailedPaths = checksumFailed.map((e) => e.path).toList();
+        await cacheManager.deleteFiles(checksumFailedPaths);
+        throw 'Checksum validation failed for: $checksumFailedPathString. \nPlease download the missing files again.';
       }
 
       // delete downloaded archives to free up disk space

--- a/flutter/unit_test/resources/cache_manager_test.dart
+++ b/flutter/unit_test/resources/cache_manager_test.dart
@@ -59,6 +59,14 @@ void main() async {
       expect(manager.getArchive(txtRemotePath), isNull);
     });
 
+    test('deleteFiles', () async {
+      await manager.deleteFiles(paths);
+      final txtLocalPath = manager.get(txtRemotePath);
+      expect(txtLocalPath, isNotNull);
+      expect(await File(txtLocalPath!).exists(), isFalse,
+          reason: 'file should not exist at path [$txtLocalPath]');
+    });
+
     test('deleteLoadedResources', () async {
       await manager.deleteLoadedResources(paths);
 


### PR DESCRIPTION
Before this PR, we would need to clear the cache (delete all the downloaded resources) or delete the corrupted file manually.