### PR TITLE
qti backend blocking other backends fix

### DIFF
--- a/mobile_back_qti/cpp/backend_qti/soc_utility.cc
+++ b/mobile_back_qti/cpp/backend_qti/soc_utility.cc
@@ -360,7 +360,6 @@ int Socs::soc_num_inits() {
 }
 
 bool Socs::isSnapDragon(const char *manufacturer) {
-  soc_info_init();
 #ifdef __ANDROID__
   bool is_qcom = false;
   if (strncmp("QUALCOMM", manufacturer, 7) == 0) {


### PR DESCRIPTION
The check for checking if its a Qualcomm device or not was happening after checking for SOC. 
Fixed the order now.