### PR TITLE
fix: made task descriptions scrollable + task title overflow fix

### DIFF
--- a/flutter/lib/ui/auto_size_text.dart
+++ b/flutter/lib/ui/auto_size_text.dart
@@ -26,16 +26,15 @@ import 'package:flutter/widgets.dart';
 /// All size constraints as well as maxLines are taken into account. If the text
 /// overflows anyway, you should check if the parent widget actually constraints
 /// the size of this widget.
-
-// TODO(Farook): make the circle padding part completely optional for general use.
-class AutoSizeCircleText extends StatefulWidget {
-  /// Creates a [AutoSizeCircleText] widget.
+class AutoSizeText extends StatefulWidget {
+  /// Creates a [AutoSizeText] widget.
   ///
   /// If the [style] argument is null, the text will use the style from the
   /// closest enclosing [DefaultTextStyle].
-  const AutoSizeCircleText(
+  const AutoSizeText(
     String this.data, {
     super.key,
+    this.circle = false,
     this.textKey,
     this.style,
     this.strutStyle,
@@ -56,10 +55,11 @@ class AutoSizeCircleText extends StatefulWidget {
     this.circularPadding = 20,
   }) : textSpan = null;
 
-  /// Creates a [AutoSizeCircleText] widget with a [TextSpan].
-  const AutoSizeCircleText.rich(
+  /// Creates a [AutoSizeText] widget with a [TextSpan].
+  const AutoSizeText.rich(
     TextSpan this.textSpan, {
     super.key,
+    this.circle = false,
     this.textKey,
     this.style,
     this.strutStyle,
@@ -84,6 +84,8 @@ class AutoSizeCircleText extends StatefulWidget {
   ///
   /// This allows you to find the actual `Text` widget built by `AutoSizeText`.
   final Key? textKey;
+
+  final bool circle;
 
   /// The text to display.
   ///
@@ -230,10 +232,10 @@ class AutoSizeCircleText extends StatefulWidget {
   final double circularPadding;
 
   @override
-  AutoSizeCircleTextState createState() => AutoSizeCircleTextState();
+  AutoSizeTextState createState() => AutoSizeTextState();
 }
 
-class AutoSizeCircleTextState extends State<AutoSizeCircleText> {
+class AutoSizeTextState extends State<AutoSizeText> {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, size) {
@@ -244,16 +246,19 @@ class AutoSizeCircleTextState extends State<AutoSizeCircleText> {
         style = defaultTextStyle.style.merge(widget.style);
       }
       if (style!.fontSize == null) {
-        style = style.copyWith(fontSize: AutoSizeCircleText._defaultFontSize);
+        style = style.copyWith(fontSize: AutoSizeText._defaultFontSize);
       }
 
       final maxLines = widget.maxLines ?? defaultTextStyle.maxLines;
 
       _validateProperties(style, maxLines);
 
-      size = size.copyWith(maxWidth: size.maxWidth - 20);
+      if (widget.circle) {
+        size = size.copyWith(maxWidth: size.maxWidth - 20);
+      }
 
-      final initialResult = _calculateFontSize(size, style, 1);
+      final initialResult =
+          widget.circle ? _calculateFontSize(size, style, 1) : [0.0, false];
       final fontSizeSingle = initialResult[0] as double;
       final textFitsSingle = initialResult[1] as bool;
 
@@ -417,7 +422,7 @@ class AutoSizeCircleTextState extends State<AutoSizeCircleText> {
       double fontSize, TextStyle style, int? maxLines, EdgeInsets padding) {
     if (widget.data != null) {
       return Padding(
-        padding: padding,
+        padding: widget.circle ? padding : const EdgeInsets.all(0.0),
         child: Text(
           widget.data!,
           key: widget.textKey,

--- a/flutter/lib/ui/home/benchmark_info_button.dart
+++ b/flutter/lib/ui/home/benchmark_info_button.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:mlperfbench/benchmark/benchmark.dart';
 import 'package:mlperfbench/localizations/app_localizations.dart';
+import 'package:mlperfbench/ui/auto_size_text.dart';
+import 'package:mlperfbench/ui/home/app_drawer.dart';
 
 class BenchmarkInfoButton extends StatelessWidget {
   final Benchmark benchmark;
@@ -23,6 +25,10 @@ class BenchmarkInfoButton extends StatelessWidget {
 
     final info = benchmark.info.getLocalizedInfo(l10n);
 
+    const double sidePadding = 18.0;
+    const double headHeight = 48.0 + (18.0 * 2);
+    const double footHeight = 36.0;
+
     showModalBottomSheet(
       context: context,
       isDismissible: false,
@@ -30,53 +36,68 @@ class BenchmarkInfoButton extends StatelessWidget {
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(24))),
-      builder: (context) => Wrap(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 20, 20, 20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Flexible(
-                  flex: 5,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
+      builder: (context) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: sidePadding),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              height: headHeight,
+              width: MediaQuery.of(context).size.width - sidePadding,
+              child: Center(
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: AutoSizeText(
                         benchmark.taskConfig.name,
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1, //can be changed to 2 without issue
                         textAlign: TextAlign.left,
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                           fontSize: 28,
                         ),
                       ),
-                    ],
-                  ),
-                ),
-                Flexible(
-                  flex: 1,
-                  child: Container(
-                    alignment: Alignment.topRight,
-                    child: IconButton(
+                    ),
+                    IconButton(
                       splashRadius: 24,
                       onPressed: () => Navigator.pop(context),
                       icon: const Icon(Icons.close, color: Colors.grey),
                     ),
+                  ],
+                ),
+              ),
+            ),
+            LayoutBuilder(builder: (context, constraints) {
+              print(constraints.maxHeight);
+              return ConstrainedBox(
+                constraints: constraints.copyWith(
+                    maxHeight: constraints.maxHeight != double.infinity
+                        ? constraints.maxHeight
+                        : MediaQuery.of(context).size.height - headHeight),
+                child: ScrollConfiguration(
+                  behavior: NoGlowScrollBehavior(),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        Text(
+                          info.detailsContent,
+                          style: const TextStyle(fontSize: 16),
+                        ),
+                        const SizedBox(
+                          height: footHeight,
+                        )
+                      ],
+                    ),
                   ),
                 ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 40),
-            child: Text(
-              info.detailsContent,
-              style: const TextStyle(fontSize: 16),
-            ),
-          ),
-        ],
+              );
+            }),
+          ],
+        ),
       ),
     );
   }

--- a/flutter/lib/ui/home/benchmark_running_screen.dart
+++ b/flutter/lib/ui/home/benchmark_running_screen.dart
@@ -161,8 +161,9 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
       color: AppColors.lightText,
     );
     if (progress.cooldown) {
-      topWidget = AutoSizeCircleText(
+      topWidget = AutoSizeText(
         l10n.progressCooldown,
+        circle: true,
         textAlign: TextAlign.center,
         style: textStyle,
         circularPadding: horizontalPadding,
@@ -201,8 +202,9 @@ class _BenchmarkRunningScreenState extends State<BenchmarkRunningScreen> {
           child: Container(
             alignment: Alignment.topCenter,
             padding: const EdgeInsets.symmetric(vertical: 4),
-            child: AutoSizeCircleText(
+            child: AutoSizeText(
               taskNameString,
+              circle: true,
               textAlign: TextAlign.center,
               style: textStyle,
               maxLines: 2,


### PR DESCRIPTION
This PR addresses #965 and fixes an overflow in the benchmark title above the description.

It also resolves a TODO on making AutoSizeText more generalized.