### PR TITLE
show download button for missing resources

### DIFF
--- a/flutter/lib/ui/error_dialog.dart
+++ b/flutter/lib/ui/error_dialog.dart
@@ -120,12 +120,12 @@ Future<void> showErrorDialog(
       context, DialogTypeEnum.error, l10n.dialogTitleError, messages);
 }
 
-Future<void> showResourceErrorDialog(
+Future<void> showResourceMissingDialog(
     BuildContext context, List<String> messages) async {
   final l10n = AppLocalizations.of(context)!;
 
-  Icon icon = const Icon(Icons.error_outline, color: Colors.red, size: 32);
-  Color titleColor = Colors.red;
+  Icon icon = const Icon(Icons.info_outline, color: Colors.grey, size: 32);
+  Color titleColor = Colors.grey;
 
   await showDialog(
     context: context,
@@ -145,7 +145,7 @@ Future<void> showResourceErrorDialog(
               children: [
                 Flexible(
                   child: Text(
-                    l10n.dialogTitleError,
+                    l10n.dialogTitleWarning,
                     style: TextStyle(
                       color: titleColor,
                       fontWeight: FontWeight.bold,

--- a/flutter/lib/ui/home/benchmark_start_screen.dart
+++ b/flutter/lib/ui/home/benchmark_start_screen.dart
@@ -120,7 +120,7 @@ class _BenchmarkStartScreenState extends State<BenchmarkStartScreen> {
                         l10n.dialogContentMissingFiles);
                 if (wrongPathError.isNotEmpty) {
                   if (!context.mounted) return;
-                  await showResourceErrorDialog(context, [wrongPathError]);
+                  await showResourceMissingDialog(context, [wrongPathError]);
                   return;
                 }
                 final checksumError = await state.validator


### PR DESCRIPTION
When the user clicks the GO button to run the benchmarks, and the required files are missing, the app displays a dialog prompting the user to download them.

<img src="https://github.com/user-attachments/assets/1953eb09-c576-4cb3-8a22-ff4e58747069" width="320">

