### PR TITLE
Increase cooldown slider max value to 30 minutes

### DIFF
--- a/flutter/lib/ui/settings/settings_screen.dart
+++ b/flutter/lib/ui/settings/settings_screen.dart
@@ -93,7 +93,7 @@ class _SettingsScreen extends State<SettingsScreen> {
     return Slider(
       value: store.cooldownDuration.toDouble(),
       min: 0,
-      max: 10 * 60,
+      max: 30 * 60,
       divisions: null,
       label: store.cooldownDuration.toString(),
       onChanged: store.cooldown


### PR DESCRIPTION
The maximum value for the cooldown duration slider has been updated from 10 minutes to 30 minutes. This change allows users greater flexibility in setting longer cooldown durations.