### PR TITLE
Feat simple resource flow

### DIFF
--- a/flutter/lib/l10n/app_en.arb
+++ b/flutter/lib/l10n/app_en.arb
@@ -91,7 +91,7 @@
   "dialogCancel": "Cancel",
   "dialogTitleConfirm": "Confirm?",
   "dialogContentOfflineWarning": "Offline mode is enabled but following internet resources are defined in the configuration. Do you want to continue?",
-  "dialogContentMissingFiles": "The following files don't exist:",
+  "dialogContentMissingFiles": "MLPerf Mobile needs to download some ML model files used by the various benchmark tests. Some of these files can be fairly large, so we recommend connecting to Wi-Fi before downloading, if possible.\n\nOnce the files are downloaded, they will be cached and can be used to run the benchmark tests repeatedly. You can manage the downloaded model files by going to Resources in the app menu.",
   "dialogContentMissingFilesHint": "Please go to the menu Resources to download the missing files.",
   "dialogContentChecksumError": "The following files failed checksum validation:",
   "dialogContentChecksumErrorHint": "Please go to the menu Resources to clear the cache and download the files again.",

--- a/flutter/lib/ui/error_dialog.dart
+++ b/flutter/lib/ui/error_dialog.dart
@@ -124,7 +124,8 @@ Future<void> showResourceMissingDialog(
     BuildContext context, List<String> messages) async {
   final l10n = AppLocalizations.of(context)!;
 
-  Icon icon = const Icon(Icons.warning_amber_rounded, color: Colors.amber, size: 32);
+  Icon icon =
+      const Icon(Icons.warning_amber_rounded, color: Colors.amber, size: 32);
   Color titleColor = Colors.grey;
 
   await showDialog(
@@ -189,7 +190,9 @@ Future<void> showResourceMissingDialog(
                     Navigator.of(context).pop();
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (context) => const ResourcesScreen(autoStart: true,),
+                        builder: (context) => const ResourcesScreen(
+                          autoStart: true,
+                        ),
                       ),
                     );
                   },

--- a/flutter/lib/ui/error_dialog.dart
+++ b/flutter/lib/ui/error_dialog.dart
@@ -124,7 +124,7 @@ Future<void> showResourceMissingDialog(
     BuildContext context, List<String> messages) async {
   final l10n = AppLocalizations.of(context)!;
 
-  Icon icon = const Icon(Icons.info_outline, color: Colors.grey, size: 32);
+  Icon icon = const Icon(Icons.warning_amber_rounded, color: Colors.amber, size: 32);
   Color titleColor = Colors.grey;
 
   await showDialog(
@@ -164,37 +164,7 @@ Future<void> showResourceMissingDialog(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                padding: const EdgeInsets.all(4),
-                decoration: BoxDecoration(
-                  color: Colors.amber.withOpacity(0.2),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.amber, width: 1),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.info_outline, color: Colors.amber),
-                    const SizedBox(width: 10),
-                    Flexible(
-                      child: Text(
-                        l10n.dialogContentMissingFilesHint,
-                        style: const TextStyle(
-                          fontSize: 14,
-                          color: Colors.black87,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 10),
-              ...messages.map((e) => Padding(
-                    padding: const EdgeInsets.only(bottom: 8.0),
-                    child: Text(
-                      e,
-                      style: const TextStyle(fontSize: 15),
-                    ),
-                  )),
+              Text(l10n.dialogContentMissingFiles),
             ],
           ),
         ),
@@ -219,7 +189,7 @@ Future<void> showResourceMissingDialog(
                     Navigator.of(context).pop();
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                        builder: (context) => const ResourcesScreen(),
+                        builder: (context) => const ResourcesScreen(autoStart: true,),
                       ),
                     );
                   },


### PR DESCRIPTION
This PR simplifies the resource downloading flow by removing the list of missing files from the warning dialog and making the "Download" button automatically start the download for necessary resources (instead of just going to the resources page).

It also changes the text of the dialog and the location of the "download all" button in accordance with #1013.

This PR is a bit rushed because of Wednesday's release, therefore I'll keep the related issue and branch, and experiment a little bit with making the flow even more straightforward after this is merged.