### PR TITLE
chore: Increase targetSdkVersion from 34 to 35

### DIFF
--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         applicationId "org.mlcommons.android.mlperfbench"
         minSdkVersion 30
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Similar to #896, PlayStore sent an email to every developer not targeting API 35.