### PR TITLE
chore(deps): update GitHub Actions workflows to use full commit SHA hash

### DIFF
--- a/.github/workflows/android-build-test.yml
+++ b/.github/workflows/android-build-test.yml
@@ -17,24 +17,24 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata for Docker image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ghcr.io/mlcommons/mobile_app_open-android
           flavor: latest=true
           tags: type=raw,value=${{ github.run_number }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: flutter/android/docker
           file: flutter/android/docker/Dockerfile
@@ -67,7 +67,7 @@ jobs:
       SIGNING_KEY_ALIAS: upload
       SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       # Preinstalled tools from host at `/opt/hostedtoolcache` is not needed since we run commands inside our own Docker container.
       # `/opt/hostedtoolcache` is mounted to `/__t`. We delete it to free up disk space.
       - name: Free up disk space
@@ -84,11 +84,11 @@ jobs:
           echo "$SIGNING_STORE_FILE_BASE64" | base64 -d > "$SIGNING_STORE_FILE"
           echo e4699f58310b85cbcb9e835e569e7e17  "$SIGNING_STORE_FILE" | md5sum --check -
       - name: Set up authentication for Google Cloud SDK
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_MOBILE_APP_BUILD }}
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           version: '>= 363.0.0'
           project_id: mobile-app-build-290400
@@ -118,7 +118,7 @@ jobs:
           rm /tmp/${QTI_LIB}.zip && \
           mv /tmp/${QTI_LIB}/* mobile_back_qti/cpp/backend_qti/StableDiffusionShared/
       - name: Cache bazel
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /tmp/bazel_cache
           key: ${{ runner.os }}-bazel_cache-${{ hashFiles('**/BUILD', '**/WORKSPACE') }}
@@ -206,49 +206,49 @@ jobs:
           gsutil cp flutter/build/app/outputs/bundle/release/app-release.aab $GCLOUD_BUCKET_PATH/app-release.aab
           gsutil cp flutter/build/app/outputs/flutter-apk/app-release.apk $GCLOUD_BUCKET_PATH/app-release.apk
       - name: Archive APK with TFLite backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-apk-tflite-${{ github.run_number }}
           path: output/android-apks/*-t-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
       - name: Archive APK with Pixel backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-apk-pixel-${{ github.run_number }}
           path: output/android-apks/*-g-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
       - name: Archive APK with QTI backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-apk-qti-${{ github.run_number }}
           path: output/android-apks/*-q-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
       - name: Archive APK with MediaTek backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-apk-mtk-${{ github.run_number }}
           path: output/android-apks/*-m-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
       - name: Archive APK with Samsung backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-apk-samsung-${{ github.run_number }}
           path: output/android-apks/*-s-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
       - name: Archive APK with unified backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-apk-unified-${{ github.run_number }}
           path: output/android-apks/*-qsmgt-${{ github.run_number }}.apk
           retention-days: 28
           if-no-files-found: error
       - name: Archive AAB with unified backend
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android-aab-unified-${{ github.run_number }}
           path: output/android-apks/*-qsmgt-${{ github.run_number }}.aab
@@ -280,13 +280,13 @@ jobs:
       HELPER_APK_NAME: test-helper-unified-${{ github.run_number }}.apk
       BROWSERSTACK_LOGS_DIR: /tmp/browserstack-device-logs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Set up authentication for Google Cloud SDK
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_MOBILE_APP_BUILD }}
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           version: '>= 363.0.0'
       - name: Download test APK
@@ -305,7 +305,7 @@ jobs:
           -X POST "https://api-cloud.browserstack.com/app-automate/flutter-integration-tests/v2/android/test-suite" \
           -F "file=@/tmp/$HELPER_APK_NAME" \
           -F "custom_id=$HELPER_APK_NAME"
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         name: Trigger App Automate
         env:
           BROWSERSTACK_CREDENTIALS: ${{ secrets.BROWSERSTACK_CREDENTIALS }}
@@ -324,7 +324,7 @@ jobs:
           command: |
             bash .github/workflows/scripts/browserstack-app-automate.sh
       - name: Upload BrowserStack logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: logs-${{ matrix.backend }}-${{ matrix.device }}-${{ github.run_number }}
@@ -359,13 +359,13 @@ jobs:
       HELPER_APK_NAME: test-helper-${{ matrix.backend }}-${{ github.run_number }}.apk
       BROWSERSTACK_LOGS_DIR: /tmp/browserstack-device-logs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Set up authentication for Google Cloud SDK
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_MOBILE_APP_BUILD }}
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           version: '>= 363.0.0'
       - name: Download test APK
@@ -384,7 +384,7 @@ jobs:
           -X POST "https://api-cloud.browserstack.com/app-automate/flutter-integration-tests/v2/android/test-suite" \
           -F "file=@/tmp/$HELPER_APK_NAME" \
           -F "custom_id=$HELPER_APK_NAME"
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         name: Trigger App Automate
         env:
           BROWSERSTACK_CREDENTIALS: ${{ secrets.BROWSERSTACK_CREDENTIALS }}
@@ -403,7 +403,7 @@ jobs:
           command: |
             bash .github/workflows/scripts/browserstack-app-automate.sh
       - name: Upload BrowserStack logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: logs-${{ matrix.backend }}-${{ matrix.device }}-${{ github.run_number }}
@@ -418,13 +418,13 @@ jobs:
     runs-on: ubuntu-22.04
     if: vars.DEPLOY_PLAYSTORE == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Set up authentication for Google Cloud SDK
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           credentials_json: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_MOBILE_APP_BUILD }}
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
         with:
           version: '>= 363.0.0'
           project_id: mobile-app-build-290400
@@ -432,7 +432,7 @@ jobs:
         run: |
           gsutil cp $GCLOUD_BUCKET_PATH/app-release.aab /tmp/app-release.aab
       - name: Upload Android release app to Google Play
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1.1.3
         with:
           releaseFiles: /tmp/app-release.aab
           packageName: org.mlcommons.android.mlperfbench

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       WITH_PIXEL: 1
       FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
       - name: Free up disk space
@@ -39,22 +39,22 @@ jobs:
           echo AFTER:
           df -h
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata for base image
         id: meta-base
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ghcr.io/mlcommons/mobile_app_open-base
           flavor: latest=true
           tags: type=raw,value=${{ github.run_number }}
       - name: Build and push base image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: flutter/android/docker
           file: flutter/android/docker/Dockerfile
@@ -65,13 +65,13 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Extract metadata for scanner image
         id: meta-scanner
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ghcr.io/mlcommons/mobile_app_open-scanner
           flavor: latest=true
           tags: type=raw,value=${{ github.run_number }}
       - name: Build and push scanner image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: tools/scanner
           file: tools/scanner/Dockerfile
@@ -94,11 +94,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
         with:
           languages: java-kotlin, javascript-typescript, python, actions
           build-mode: none
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -14,24 +14,24 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ghcr.io/mlcommons/mobile_app_open-formatter
           flavor: latest=true
           tags: type=raw,value=${{ github.run_number }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: tools/formatter
           file: tools/formatter/Dockerfile
@@ -48,7 +48,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: bazel
@@ -62,7 +62,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: clang
@@ -75,11 +75,11 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Cache Flutter packages
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /home/mlperf/.pub-cache
           key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
@@ -98,7 +98,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: swift
@@ -111,7 +111,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: markdown-format
@@ -124,7 +124,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: pbtxt
@@ -137,7 +137,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: yaml
@@ -151,7 +151,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: typescripts
@@ -164,7 +164,7 @@ jobs:
       image: ghcr.io/mlcommons/mobile_app_open-formatter:${{ github.run_number }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: configure Git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: prohibited-extensions

--- a/.github/workflows/ios-build-test.yml
+++ b/.github/workflows/ios-build-test.yml
@@ -34,15 +34,15 @@ jobs:
       FIREBASE_CRASHLYTICS_ENABLED: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ github.workspace }}/flutter/ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-
       - name: Cache bazel
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: /tmp/bazel_cache
           key: ${{ runner.os }}-bazel_cache-${{ hashFiles('**/BUILD', '**/WORKSPACE') }}
@@ -59,7 +59,7 @@ jobs:
       - name: Build iOS integration tests
         run: |
           cd flutter && flutter --no-version-check build ios --simulator integration_test/first_test.dart
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         name: Run iOS integration tests
         with:
           timeout_minutes: 120

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # v2.19.0
         with:
           channel: 'stable'
           flutter-version: '3.19.6'
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Build website
         env:
           REACT_APP_FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
@@ -27,7 +27,7 @@ jobs:
           cd ./react
           yarn install --immutable --immutable-cache --check-cache
           yarn build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         name: Deploy to Firebase Hosting on Preview channel
         if: github.ref != 'refs/heads/master'
         with:
@@ -36,7 +36,7 @@ jobs:
           projectId: mobile-app-build-290400
           entryPoint: "./react"
           expires: 30d
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
         name: Deploy to Firebase Hosting on Live channel
         if: github.ref == 'refs/heads/master'
         with:


### PR DESCRIPTION
This PR fix this Security Hotspots reported by Sonar Cloud:

Use full commit SHA hash for this dependency.
Using external GitHub actions and workflows without a commit reference is security-sensitive [githubactions:S7637](https://sonarcloud.io/organizations/mlcommons/rules?open=githubactions%3AS7637&rule_key=githubactions%3AS7637)