### PR TITLE
Add merge_group trigger to be able to use merge queue

### DIFF
--- a/.github/workflows/android-build-test-linux.yml
+++ b/.github/workflows/android-build-test-linux.yml
@@ -4,11 +4,13 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
-  workflow_dispatch:
+  merge_group:
+    types: [ checks_requested ]
 
 env:
   GCLOUD_BUCKET_PATH: gs://mobile-app-build-290400_github-actions/build/${{ github.run_number }}

--- a/.github/workflows/android-build-test-macos.yml
+++ b/.github/workflows/android-build-test-macos.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   build:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   cla-check:

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   sonar:

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   build-image:

--- a/.github/workflows/ios-build-test-macos.yml
+++ b/.github/workflows/ios-build-test-macos.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, submission-v* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
+    types: [ checks_requested ]
 
 jobs:
   flutter:


### PR DESCRIPTION
* Closes https://github.com/mlcommons/mobile_app_open/issues/1063

Currently, our CI checks run on every new push to a pull request. However, some checks, particularly the integration tests, take a long time and incur higher costs. To address this issue, we can optimize the process by running the tests only before merging into the main branch, rather than on every push, by using a merge queue.