### PR TITLE
Fix android build on MacOS

### DIFF
--- a/flutter/android/android.mk
+++ b/flutter/android/android.mk
@@ -57,6 +57,7 @@ flutter/android/libs/build:
 	bazel ${BAZEL_OUTPUT_ROOT_ARG} ${proxy_bazel_args} ${sonar_bazel_startup_options} \
 		build ${BAZEL_CACHE_ARG} ${bazel_links_arg} ${sonar_bazel_build_args} \
 		--config=android_arm64 \
+		--platforms=//platforms:android_arm64 \
 		${backend_tflite_android_target} \
 		${backend_mediatek_android_target} \
 		${backend_pixel_android_target} \

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,0 +1,7 @@
+platform(
+    name = "android_arm64",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:arm64",
+    ],
+)


### PR DESCRIPTION
This PR fixes CI issues relating to the new submission branch.

The issue most likely occurs due to updating Tensorflow, which uses an updated bazel version and updated "platform" instructions.

This platform is specified as ios, and since our current config doesn't override it, it tries to use ios build options regardless of target.