### PR TITLE
Config based LLM pipeline thread count

### DIFF
--- a/mobile_back_tflite/cpp/backend_tflite/llm_pipeline.cc
+++ b/mobile_back_tflite/cpp/backend_tflite/llm_pipeline.cc
@@ -73,8 +73,18 @@ mlperf_backend_ptr_t LLMPipeline::backend_create(
     return nullptr;
   }
 
+  // Get the thread count in config
+  for (size_t i = 0; i < configs->count; ++i) {
+    if (strcmp(configs->keys[i], "num_threads") == 0) {
+      if (int value = atoi(configs->values[i]); value != 0) {
+        backend_data->num_threads = static_cast<uint16_t>(value);
+        break;
+      }
+    }
+  }
+
   backend_data->interpreter =
-      BuildInterpreter(backend_data->model, backend_data->threads);
+      BuildInterpreter(backend_data->model, backend_data->num_threads);
   if (!backend_data->interpreter) {
     LOG(ERROR) << "Failed to load interpreter";
     backend_delete(backend_data);

--- a/mobile_back_tflite/cpp/backend_tflite/llm_pipeline.h
+++ b/mobile_back_tflite/cpp/backend_tflite/llm_pipeline.h
@@ -151,7 +151,7 @@ struct LLMBackendData {
   kv_cache_t kv_cache;
   std::vector<int> prompt_tokens;
   std::vector<int> output_tokens;
-  uint8_t threads = 8;
+  uint16_t num_threads = 4;
   int max_output_tokens = 128;
   std::unordered_set<int> stop_token_ids{128001, 128008, 128009};
 


### PR DESCRIPTION
This PR uses the logic from `SingleModelPipeline` to assign the thread count in the TFLite config to the `LLMPipeline`.