### PR TITLE
LLM dataset limit updates

### DIFF
--- a/flutter/cpp/binary/main.cc
+++ b/flutter/cpp/binary/main.cc
@@ -418,8 +418,8 @@ int Main(int argc, char *argv[]) {
 
       if (Flags::Parse(&argc, const_cast<const char **>(argv), dataset_flags) &&
           backend) {
-        dataset.reset(
-            new MmluGen(backend.get(), input_tfrecord, sp_path, zero_shot));
+        dataset.reset(new MmluGen(backend.get(), input_tfrecord, sp_path,
+                                  zero_shot, Str2TestMode(mode)));
       }
       // Adds to flag_list for showing help.
       flag_list.insert(flag_list.end(), dataset_flags.begin(),
@@ -471,9 +471,10 @@ int Main(int argc, char *argv[]) {
   // Running mlperf.
   MlperfDriver driver(std::move(dataset), std::move(backend), scenario,
                       batch_size);
-  driver.RunMLPerfTest(
-      mode, min_query_count, min_duration_ms / 1000.0, max_duration_ms / 1000.0,
-      single_stream_expected_latency_ns, output_dir, benchmark_id == "llm");
+  driver.RunMLPerfTest(mode, min_query_count, min_duration_ms / 1000.0,
+                       max_duration_ms / 1000.0,
+                       single_stream_expected_latency_ns, output_dir,
+                       (benchmark_id.rfind("llm", 0) == 0));
   LOG(INFO) << "Accuracy: " << driver.ComputeAccuracyString();
   return 0;
 }

--- a/flutter/cpp/dataset.h
+++ b/flutter/cpp/dataset.h
@@ -41,6 +41,7 @@ class Dataset : public ::mlperf::QuerySampleLibrary {
   ~Dataset() override {}
 
   // The number of samples that are guaranteed to fit in RAM.
+  // Returning 0 means performance mode should not run.
   size_t PerformanceSampleCount() override {
     int sample_size = 0;
     for (const DataType& data_type : input_format_) {

--- a/flutter/cpp/datasets/ifeval.cc
+++ b/flutter/cpp/datasets/ifeval.cc
@@ -169,7 +169,9 @@ float IFEval::ComputeAccuracy() {
 
 std::string IFEval::ComputeAccuracyString() {
   float acc = ComputeAccuracy();
-  return "Accuracy: " + std::to_string(acc * 100.0f) + "%";
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(4) << acc * 100.0f << "%";
+  return stream.str();
 }
 
 inline std::vector<std::unique_ptr<ifeval::Instruction>>

--- a/flutter/cpp/datasets/ifeval.h
+++ b/flutter/cpp/datasets/ifeval.h
@@ -81,8 +81,8 @@ class IFEval : public Dataset {
   std::unordered_set<size_t> used_sample_ids_;
   std::set<int> loaded_sample_ids_;
   std::unique_ptr<sentencepiece::SentencePieceProcessor> sp_processor;
-  static constexpr int input_token_limit_ = 1024;
-  static constexpr int token_limit_ = 1024;
+  static constexpr int input_token_limit_ = 2048;
+  int token_limit_ = 1024;
 };
 
 }  // namespace mobile

--- a/flutter/cpp/datasets/mmlu_gen.cc
+++ b/flutter/cpp/datasets/mmlu_gen.cc
@@ -11,7 +11,8 @@ namespace mlperf {
 namespace mobile {
 
 MmluGen::MmluGen(Backend* backend, const std::string& input_tfrecord,
-                 const std::string& sp_path, bool zero_shot)
+                 const std::string& sp_path, bool zero_shot,
+                 ::mlperf::TestMode mode)
     : sample_reader_(input_tfrecord), Dataset(backend) {
   sp_processor = std::unique_ptr<sentencepiece::SentencePieceProcessor>(
       LoadSentencePieceProcessor(sp_path));
@@ -27,6 +28,9 @@ MmluGen::MmluGen(Backend* backend, const std::string& input_tfrecord,
         tensorflow::GetFeatureValues<std::string>("input", example).Get(0);
     std::string answer =
         tensorflow::GetFeatureValues<std::string>("answer", example).Get(0);
+
+    // Set output token limit to 128 if performance mode is being used
+    if (mode == ::mlperf::TestMode::PerformanceOnly) token_limit_ = 128;
 
     if (zero_shot) {
       // input-formatted shots are separated by 2 new lines, so we find the last
@@ -47,19 +51,16 @@ MmluGen::MmluGen(Backend* backend, const std::string& input_tfrecord,
 
     // input token sanity check
     while (input_tokens.size() > input_token_limit_) {
-      LOG(WARNING) << "Input token limit exceeded for entry "
-                   << std::to_string(i) << ". Truncating.";
-
       size_t cur = input.find("\n\n") + 2;
       std::string preface = input.substr(0, cur);
       std::string truncated_shots = input.substr(input.find("\n\n", cur) + 2);
 
       input = preface + truncated_shots;
 
-      // LOG(WARNING) << "new string: " << input;
-
       sp_processor->Encode(input.c_str(), &input_tokens).ok();
-      LOG(WARNING) << "new size: " << input_tokens.size();
+      LOG(WARNING) << "Input token limit exceeded for entry "
+                   << std::to_string(i) << ". Truncated to "
+                   << input_tokens.size();
     }
 
     auto sample = std::make_unique<PromptSample>();
@@ -138,7 +139,10 @@ float MmluGen::ComputeAccuracy() {
 
 std::string MmluGen::ComputeAccuracyString() {
   float acc = ComputeAccuracy();
-  return "Accuracy: " + std::to_string(acc * 100.0f) + "%";
+
+  std::stringstream stream;
+  stream << std::fixed << std::setprecision(4) << acc * 100.0f << "%";
+  return stream.str();
 }
 
 char MmluGen::find_answer_char(const std::string& input) {

--- a/flutter/cpp/datasets/mmlu_gen.h
+++ b/flutter/cpp/datasets/mmlu_gen.h
@@ -12,6 +12,7 @@
 
 #include "flutter/cpp/dataset.h"
 #include "flutter/cpp/datasets/squad_utils/tfrecord_reader.h"
+#include "loadgen/test_settings.h"
 #include "src/sentencepiece_processor.h"
 
 namespace mlperf {
@@ -20,7 +21,7 @@ namespace mobile {
 class MmluGen : public Dataset {
  public:
   MmluGen(Backend* backend, const std::string& input_tfrecord,
-          const std::string& sp_path, bool zero_shot);
+          const std::string& sp_path, bool zero_shot, ::mlperf::TestMode mode);
 
   const std::string& Name() override { return name_; }
 
@@ -66,8 +67,8 @@ class MmluGen : public Dataset {
   std::unordered_set<size_t> used_sample_ids_;
   std::set<int> loaded_sample_ids_;
   std::unique_ptr<sentencepiece::SentencePieceProcessor> sp_processor;
-  static constexpr int input_token_limit_ = 1024;
-  static constexpr int token_limit_ = 4;
+  static constexpr int input_token_limit_ = 2048;
+  int token_limit_ = 4;
 };
 
 }  // namespace mobile

--- a/flutter/cpp/flutter/dart_run_benchmark.cc
+++ b/flutter/cpp/flutter/dart_run_benchmark.cc
@@ -19,6 +19,7 @@
 #include "flutter/cpp/mlperf_driver.h"
 #include "flutter/cpp/proto/backend_setting.pb.h"
 #include "flutter/cpp/proto/mlperf_task.pb.h"
+#include "flutter/cpp/utils.h"
 
 static ::mlperf::mobile::MlperfDriver* global_driver = nullptr;
 static ::std::mutex global_driver_mutex;
@@ -119,7 +120,8 @@ struct dart_ffi_run_benchmark_out* dart_ffi_run_benchmark(
       sp_path += '/' + sp_path_filename;
       use_token_latencies = true;
       dataset = std::make_unique<::mlperf::mobile::MmluGen>(
-          backend.get(), in->dataset_data_path, sp_path, false /*zero-shot*/);
+          backend.get(), in->dataset_data_path, sp_path, false /*zero-shot*/,
+          mlperf::mobile::Str2TestMode(in->mode));
       break;
     case ::mlperf::mobile::DatasetConfig::IFEVAL:
       for (auto setting : settings.benchmark_setting().custom_setting()) {

--- a/flutter/cpp/mlperf_driver.cc
+++ b/flutter/cpp/mlperf_driver.cc
@@ -135,7 +135,13 @@ void MlperfDriver::RunMLPerfTest(const std::string& mode, int min_query_count,
   use_tokens_ = use_tokens;
   mlperf_settings.use_token_latencies = use_tokens;
   // mlperf_settings.server_target_qps = 0.1;
-  mlperf_settings.mode = Str2TestMode(mode);
+
+  // Prevent datasets with performance sample count 0 from running.
+  ::mlperf::TestMode runMode = Str2TestMode(mode);
+  if (dataset_->PerformanceSampleCount() == 0)
+    runMode = ::mlperf::TestMode::AccuracyOnly;
+
+  mlperf_settings.mode = runMode;
   mlperf_settings.min_duration_ms =
       static_cast<uint64_t>(std::ceil(min_duration * 1000.0));
   // Note: max_duration_ms works only in SingleStream scenario.


### PR DESCRIPTION
This PR addressed the points discussed in #1098 regarding datasets (specifically MMLU).

It does the following:
- Prevent performance mode from running when query count is 0

- set input/output token limits to 2048/1024 for IFEval and 2048/(4|128) for MMLU.

- Update accuracy string format for MMLU and IFEval (from `Accuracy: 50%` to `50%` for an accuracy of `0.5`)