### PR TITLE
chore: bump app version to 5.0.5

### DIFF
--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 # version format: <semantic_app_version>+<build_number>.
 # Note: build_number will be set by CI using the CLI option --build-number
-version: 5.0.4+1
+version: 5.0.5+1
 
 environment:
   sdk: ^3.3.4  # Dart SDK version


### PR DESCRIPTION
## Summary
- Bump app version from 5.0.4 to 5.0.5 in `flutter/pubspec.yaml`
- Version 5.0.4 is already published on the Apple App Store, causing Xcode Cloud deployment failures

## Test plan
- [ ] Verify Xcode Cloud build succeeds with the new version
- [ ] Confirm App Store Connect accepts the new version number