### PR TITLE
small fixes for LLM config

### DIFF
--- a/flutter/assets/tasks.pbtxt
+++ b/flutter/assets/tasks.pbtxt
@@ -14,7 +14,6 @@ task_set {
     opt {
       id: "online"
       name: "Online"
-      enabled: true
     }
   }
 }
@@ -28,7 +27,6 @@ task_set {
     opt {
       id: "1b"
       name: "1B"
-      enabled: true
     }
     opt {
       id: "3b"

--- a/flutter/cpp/datasets/ifeval.cc
+++ b/flutter/cpp/datasets/ifeval.cc
@@ -179,6 +179,28 @@ float IFEval::ComputeAccuracy() {
                 accuracy.prompt_total
           : 0.0f;
 
+  std::string filename = raw_output_dir_ + "/accuracy.txt";
+  std::ofstream file(filename);
+  if (file.is_open()) {
+    file << "Instruction-level loose-accuracy: "
+         << std::to_string(accuracy.instruction_correct_loose) << '/'
+         << std::to_string(accuracy.instruction_total) << " = "
+         << std::to_string(instruction_loose_accuracy) << std::endl;
+    file << "Instruction-level strict-accuracy: "
+         << std::to_string(accuracy.instruction_correct_strict) << '/'
+         << std::to_string(accuracy.instruction_total) << " = "
+         << std::to_string(instruction_strict_accuracy) << std::endl;
+    file << "Prompt-level loose-accuracy: "
+         << std::to_string(accuracy.prompt_correct_loose) << '/'
+         << std::to_string(accuracy.prompt_total) << " = "
+         << std::to_string(prompt_loose_accuracy) << std::endl;
+    file << "Prompt-level strict-accuracy: "
+         << std::to_string(accuracy.prompt_correct_strict) << '/'
+         << std::to_string(accuracy.prompt_total) << " = "
+         << std::to_string(prompt_strict_accuracy) << std::endl;
+    file.close();
+  }
+
   LOG(INFO) << "Instruction-level loose-accuracy: "
             << std::to_string(instruction_loose_accuracy);
   LOG(INFO) << "Instruction-level strict-accuracy: "

--- a/flutter/cpp/datasets/ifeval.cc
+++ b/flutter/cpp/datasets/ifeval.cc
@@ -179,28 +179,6 @@ float IFEval::ComputeAccuracy() {
                 accuracy.prompt_total
           : 0.0f;
 
-  std::string filename = raw_output_dir_ + "/accuracy.txt";
-  std::ofstream file(filename);
-  if (file.is_open()) {
-    file << "Instruction-level loose-accuracy: "
-         << std::to_string(accuracy.instruction_correct_loose) << '/'
-         << std::to_string(accuracy.instruction_total) << " = "
-         << std::to_string(instruction_loose_accuracy) << std::endl;
-    file << "Instruction-level strict-accuracy: "
-         << std::to_string(accuracy.instruction_correct_strict) << '/'
-         << std::to_string(accuracy.instruction_total) << " = "
-         << std::to_string(instruction_strict_accuracy) << std::endl;
-    file << "Prompt-level loose-accuracy: "
-         << std::to_string(accuracy.prompt_correct_loose) << '/'
-         << std::to_string(accuracy.prompt_total) << " = "
-         << std::to_string(prompt_loose_accuracy) << std::endl;
-    file << "Prompt-level strict-accuracy: "
-         << std::to_string(accuracy.prompt_correct_strict) << '/'
-         << std::to_string(accuracy.prompt_total) << " = "
-         << std::to_string(prompt_strict_accuracy) << std::endl;
-    file.close();
-  }
-
   LOG(INFO) << "Instruction-level loose-accuracy: "
             << std::to_string(instruction_loose_accuracy);
   LOG(INFO) << "Instruction-level strict-accuracy: "

--- a/flutter/cpp/mlperf_driver.cc
+++ b/flutter/cpp/mlperf_driver.cc
@@ -130,9 +130,7 @@ void MlperfDriver::RunMLPerfTest(const std::string& mode, int min_query_count,
   mlperf_settings.sample_index_rng_seed = 14276810075590677512UL;
   mlperf_settings.schedule_rng_seed = 3936089224930324775UL;
 
-  // mlperf_settings.min_query_count = 1;
-  // mlperf_settings.max_query_count = 2;
-  // mlperf_settings.performance_sample_count_override = 5;
+  mlperf_settings.min_query_count = min_query_count;
   use_tokens_ = use_tokens;
   mlperf_settings.use_token_latencies = use_tokens;
   // mlperf_settings.server_target_qps = 0.1;

--- a/flutter/lib/backend/loadgen_info.dart
+++ b/flutter/lib/backend/loadgen_info.dart
@@ -113,6 +113,13 @@ class LoadgenInfo {
     const nanosecondsPerSecond = 1000 * Duration.microsecondsPerSecond;
     bool usesTokens = (result[useTokenLatenciesKey] ?? false) as bool;
 
+    double tokenThroughput = 1.0 /
+        (((result[tokenThroughputKey] as num?)?.toDouble() ?? 0.0) /
+            nanosecondsPerSecond);
+    if (tokenThroughput.isInfinite) {
+      tokenThroughput = 0;
+    }
+
     return LoadgenInfo(
       queryCount: result[queryCountKey] as int? ?? 0,
       latencyMean: !usesTokens
@@ -127,11 +134,7 @@ class LoadgenInfo {
       latencyFirstToken90: usesTokens
           ? (result[latency90FirstTokenKey] as int? ?? 0) / nanosecondsPerSecond
           : 0,
-      tokenThroughput: usesTokens
-          ? 1.0 /
-              (((result[tokenThroughputKey] as num?)?.toDouble() ?? 0.0) /
-                  nanosecondsPerSecond)
-          : 0,
+      tokenThroughput: usesTokens ? tokenThroughput : 0,
       isMinDurationMet: result[minDurationMetKey] as bool? ?? false,
       isMinQueryMet: result[minQueriesMetKey] as bool? ?? false,
       isEarlyStoppingMet: result[earlyStoppingMetKey] as bool? ?? false,

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt
@@ -318,7 +318,9 @@ benchmark_setting {
     id: "tokenizer_filename"
     value: "llama3_1b.spm.model"
   }
-}benchmark_setting {
+}
+
+benchmark_setting {
   benchmark_id: "llm-3b"
   framework: "TFLite"
   delegate_choice: {
@@ -341,7 +343,7 @@ benchmark_setting {
   }
   custom_setting {
     id: "model_filename"
-    value: "llama_q8_ekv3072.tflite"
+    value: "llama_3b_q8_ekv3072.tflite"
   }
   custom_setting {
     id: "tokenizer_filename"
@@ -372,13 +374,15 @@ benchmark_setting {
   }
   custom_setting {
     id: "model_filename"
-    value: "llama_q8_ekv3072.tflite"
+    value: "llama_3b_q8_ekv3072.tflite"
   }
   custom_setting {
     id: "tokenizer_filename"
     value: "llama3_1b.spm.model"
   }
-}benchmark_setting {
+}
+
+benchmark_setting {
   benchmark_id: "llm-8b"
   framework: "TFLite"
   delegate_choice: {
@@ -401,7 +405,7 @@ benchmark_setting {
   }
   custom_setting {
     id: "model_filename"
-    value: "llama_q8_ekv3072.tflite"
+    value: "llama_8b_q8_ekv3072.tflite"
   }
   custom_setting {
     id: "tokenizer_filename"
@@ -432,7 +436,7 @@ benchmark_setting {
   }
   custom_setting {
     id: "model_filename"
-    value: "llama_q8_ekv3072.tflite"
+    value: "llama_8b_q8_ekv3072.tflite"
   }
   custom_setting {
     id: "tokenizer_filename"


### PR DESCRIPTION
This PR fixes the incorrect model filename for 3B and 8B benchmarks, and disables all benchmark set options by default.