### PR TITLE
Restore MD5 checksums for v6.0 LLM tflite models and disable LLM benchmark for M32 device

### DIFF
--- a/mobile_back_tflite/cpp/backend_tflite/BUILD
+++ b/mobile_back_tflite/cpp/backend_tflite/BUILD
@@ -28,6 +28,7 @@ pbtxt2header(
     name = "tflite_settings",
     srcs = [
         "backend_settings/tflite_settings_android.pbtxt",
+        "backend_settings/tflite_settings_android_m32.pbtxt",
         "backend_settings/tflite_settings_apple_iphone11.pbtxt",
         "backend_settings/tflite_settings_apple_iphone12.pbtxt",
         "backend_settings/tflite_settings_apple_iphoneX.pbtxt",

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt
@@ -267,7 +267,7 @@ benchmark_setting {
     accelerator_desc: "CPU"
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v6_0/tflite/llama_q8_ekv3072.tflite"
-      model_checksum: ""
+      model_checksum: "c618e9bbb89ce52eedcab4f61b2dc3a4"
     }
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/datasets/v6_0/llama3_1b.spm.model"
@@ -298,7 +298,7 @@ benchmark_setting {
     accelerator_desc: "CPU"
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v6_0/tflite/llama_q8_ekv3072.tflite"
-      model_checksum: ""
+      model_checksum: "c618e9bbb89ce52eedcab4f61b2dc3a4"
     }
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/datasets/v6_0/llama3_1b.spm.model"
@@ -329,7 +329,7 @@ benchmark_setting {
     accelerator_desc: "CPU"
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v6_0/tflite/llama_3b_q8_ekv3072.tflite"
-      model_checksum: ""
+      model_checksum: "6bde54c22e2be27bdad5303a0bd9cf72"
     }
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/datasets/v6_0/llama3_1b.spm.model"
@@ -360,7 +360,7 @@ benchmark_setting {
     accelerator_desc: "CPU"
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v6_0/tflite/llama_3b_q8_ekv3072.tflite"
-      model_checksum: ""
+      model_checksum: "6bde54c22e2be27bdad5303a0bd9cf72"
     }
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/datasets/v6_0/llama3_1b.spm.model"
@@ -391,7 +391,7 @@ benchmark_setting {
     accelerator_desc: "CPU"
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v6_0/tflite/llama_8b_q8_ekv3072.tflite"
-      model_checksum: ""
+      model_checksum: "ec19cf40f881684f15db0b862883ff00"
     }
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/datasets/v6_0/llama3_1b.spm.model"
@@ -422,7 +422,7 @@ benchmark_setting {
     accelerator_desc: "CPU"
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v6_0/tflite/llama_8b_q8_ekv3072.tflite"
-      model_checksum: ""
+      model_checksum: "ec19cf40f881684f15db0b862883ff00"
     }
     model_file: {
       model_path: "https://mobile.mlcommons-storage.org/app-resources/datasets/v6_0/llama3_1b.spm.model"

--- a/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android_m32.pbtxt
+++ b/mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android_m32.pbtxt
@@ -1,0 +1,262 @@
+# proto-file: flutter/cpp/proto/backend_setting.proto
+# proto-message: BackendSetting
+
+# Settings for the Samsung Galaxy M32 (SM-M326B).
+# Identical to tflite_settings_android.pbtxt but with the LLM benchmarks
+# omitted; the device does not have enough memory to run them.
+
+common_setting {
+  id: "num_threads"
+  name: "Number of threads"
+  value {
+    value: "4"
+    name: "4 threads"
+  }
+}
+
+benchmark_setting {
+  benchmark_id: "image_classification"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v0_7/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v0_7/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "0da3fa6adc8bbaaeb0b5647e2d46c8a4"
+    }
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "image_classification_v2"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v4_0/tflite/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v4_0/tflite/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "image_classification_offline"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v0_7/mobilenet_edgetpu_224_1.0_uint8.tflite"
+      model_checksum: "008dfcb1c1962fedbeef1b998d4c84f2"
+    }
+    batch_size: 2
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v1_1/mobilenet_edgetpu_224_1.0_float.tflite"
+      model_checksum: "66bb4eba50987221608f8487ed405794"
+    }
+    batch_size: 2
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "image_classification_offline_v2"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v4_0/tflite/MobileNetV4-Conv-Large-int8-ptq.tflite"
+      model_checksum: "590a7a88640a18d28b16b6f571cdfc93"
+    }
+    batch_size: 2
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v4_0/tflite/MobileNetV4-Conv-Large-fp32.tflite"
+      model_checksum: "b57cc2a027607c3b36873a15ace84acb"
+    }
+    batch_size: 2
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "object_detection"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v1_0/mobiledet_qat.tflite"
+      model_checksum: "6c7af49d97a2b2488222d94936d2dc18"
+    }
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v1_0/mobiledet.tflite"
+      model_checksum: "566ceb72a4c7c8926fe4ac8eededb5bf"
+    }
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "natural_language_processing"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v0_7/mobilebert_int8_384_nnapi.tflite"
+      model_checksum: "3944a2dee04a5f8a5fd016ac34c4d390"
+    }
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v0_7/mobilebert_float_384_gpu.tflite"
+      model_checksum: "36a953d07a8c6f2d3e05b22e87cec95b"
+    }
+  }
+  delegate_selected: "GPU"
+}
+
+benchmark_setting {
+  benchmark_id: "image_segmentation_v2"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v2_0/mobile_segmenter_r4_quant_argmax_uint8.tflite"
+      model_checksum: "b7a7620b8b818d64305b51ab796bfb1d"
+    }
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v2_0/mobile_segmenter_r4_argmax_f32.tflite"
+      model_checksum: "b3a5d3c2e5756431a471ed5211c344a9"
+    }
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "super_resolution"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v3_0/edsr_f32b5_full_qint8.tflite"
+      model_checksum: "18ce6df0e4603f4b4ee5d04193708d9c"
+    }
+  }
+  delegate_choice: {
+    delegate_name: "GPU"
+    accelerator_name: "gpu"
+    accelerator_desc: "GPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v3_0/edsr_f32b5_fp32.tflite"
+      model_checksum: "672240427c1f3dc33baf2facacd9631f"
+    }
+  }
+  delegate_selected: "NNAPI"
+}
+
+benchmark_setting {
+  benchmark_id: "stable_diffusion"
+  framework: "TFLite"
+  delegate_choice: {
+    delegate_name: "NNAPI"
+    accelerator_name: "npu"
+    accelerator_desc: "NPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/sd_decoder_dynamic_fp16.tflite"
+      model_checksum: "165b70a01643e70a23e5e54a949be306"
+    }
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/sd_diffusion_model_dynamic_int8.tflite"
+      model_checksum: "ccfd761a2f8186c3669948515d40a880"
+    }
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/sd_text_encoder_dynamic_int8.tflite"
+      model_checksum: "b64effb0360f9ea49a117cdaf8a2fbdc"
+    }
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/timestep_embeddings_data.bin.ts"
+      model_checksum: "798b772155a69de5df44b304327bb3cc"
+    }
+  }
+  delegate_selected: "NNAPI"
+  custom_setting {
+    id: "pipeline"
+    value: "StableDiffusionPipeline"
+  }
+  custom_setting {
+    id: "pipeline"
+    value: "StableDiffusionPipeline"
+  }
+  custom_setting {
+    id: "text_encoder_filename"
+    value: "sd_text_encoder_dynamic_int8.tflite"
+  }
+  custom_setting {
+    id: "diffusion_model_filename"
+    value: "sd_diffusion_model_dynamic_int8.tflite"
+  }
+  custom_setting {
+    id: "decoder_filename"
+    value: "sd_decoder_dynamic_fp16.tflite"
+  }
+  custom_setting {
+    id: "timestep_embeddings_filename"
+    value: "timestep_embeddings_data.bin.ts"
+  }
+}

--- a/mobile_back_tflite/cpp/backend_tflite/tflite_c.cc
+++ b/mobile_back_tflite/cpp/backend_tflite/tflite_c.cc
@@ -163,7 +163,14 @@ bool mlperf_backend_matches_hardware(const char **not_allowed_message,
 #elif defined(_WIN64) || defined(_WIN32)
   *settings = tflite_settings_windows.c_str();
 #else
-  *settings = tflite_settings_android.c_str();
+  // Samsung Galaxy M32 (SM-M326B) does not have enough memory to run LLM
+  // benchmarks, so use a settings file that omits them.
+  if (device_info->model != nullptr &&
+      strcmp(device_info->model, "SM-M326B") == 0) {
+    *settings = tflite_settings_android_m32.c_str();
+  } else {
+    *settings = tflite_settings_android.c_str();
+  }
 #endif
   LOG(INFO) << "TFLite backend matches hardware";
   return true;

--- a/mobile_back_tflite/cpp/backend_tflite/tflite_settings_android.h
+++ b/mobile_back_tflite/cpp/backend_tflite/tflite_settings_android.h
@@ -16,7 +16,9 @@ limitations under the License.
 #define TFLITE_SETTINGS_ANDROID_H
 
 #include "mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android.pbtxt.h"
+#include "mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android_m32.pbtxt.h"
 
 const std::string tflite_settings_android = tflite_settings_android_pbtxt;
+const std::string tflite_settings_android_m32 = tflite_settings_android_m32_pbtxt;
 
 #endif

--- a/mobile_back_tflite/cpp/backend_tflite/tflite_settings_android.h
+++ b/mobile_back_tflite/cpp/backend_tflite/tflite_settings_android.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include "mobile_back_tflite/cpp/backend_tflite/backend_settings/tflite_settings_android_m32.pbtxt.h"
 
 const std::string tflite_settings_android = tflite_settings_android_pbtxt;
-const std::string tflite_settings_android_m32 = tflite_settings_android_m32_pbtxt;
+const std::string tflite_settings_android_m32 =
+    tflite_settings_android_m32_pbtxt;
 
 #endif


### PR DESCRIPTION
The empty model_checksum entries (introduced in #1113 to ease testing with custom models) caused the integration test validateSettings() to fail for every benchmark, since it iterates allBenchmarks regardless of which benchmark is under test.

Checksums computed from the published model files:
- llama_q8_ekv3072.tflite    -> c618e9bbb89ce52eedcab4f61b2dc3a4
- llama_3b_q8_ekv3072.tflite -> 6bde54c22e2be27bdad5303a0bd9cf72
- llama_8b_q8_ekv3072.tflite -> ec19cf40f881684f15db0b862883ff00

Disable the LLM benchmark for the Samsung Galaxy M32 used in CI tests as it's not supported.