### PR TITLE
Remove empty sets from results screen

### DIFF
--- a/flutter/lib/ui/home/benchmark_result_screen.dart
+++ b/flutter/lib/ui/home/benchmark_result_screen.dart
@@ -226,8 +226,11 @@ class _BenchmarkResultScreenState extends State<BenchmarkResultScreen>
       children: <Widget>[
         // 1. Render Benchmark Sets (Expandable)
         for (var benchmarkSet in state.benchmarkSets) ...[
-          _benchmarkSetResultRow(benchmarkSet),
-          const Divider(height: 1),
+          if (benchmarkSet.benchmarks.isNotEmpty)
+            _benchmarkSetResultRow(benchmarkSet),
+          if (benchmarkSet != state.benchmarkSets.last ||
+              state.looseBenchmarks.isNotEmpty)
+            const Divider(height: 1),
         ],
         // 2. Render Loose Benchmarks (Stand-alone)
         for (var benchmark in state.looseBenchmarks) ...[


### PR DESCRIPTION
This PR fixes the issue in #1144 regarding phantom llm entries.

It uses the same logic as in the config section.