### PR TITLE
docs: add Llama model and OSS licenses to in-app About screen

### DIFF
--- a/flutter/assets/text/about.md
+++ b/flutter/assets/text/about.md
@@ -85,4 +85,20 @@ For more information about Core ML, visit [https://developer.apple.com/documenta
 
 The MLPerf Mobile App code is licensed under the Apache 2.0 License. The models used in the benchmarks are subject to their respective licenses. For detailed licensing information, please refer to the [LICENSE.md](https://github.com/mlcommons/mobile_app_open/blob/master/LICENSE.md) file in the repository.
 
+### Large Language Models
+
+The LLM benchmarks in this app are built with Llama. The following Meta Llama models are used, and your use of them is governed by the Llama Community License Agreement and the Llama Acceptable Use Policy:
+
+* Llama 3.1 8B-Instruct — Llama 3.1 Community License Agreement ([https://www.llama.com/llama3_1/license/](https://www.llama.com/llama3_1/license/)) and Acceptable Use Policy ([https://www.llama.com/llama3_1/use-policy/](https://www.llama.com/llama3_1/use-policy/))
+* Llama 3.2 3B-Instruct — Llama 3.2 Community License Agreement ([https://www.llama.com/llama3_2/license/](https://www.llama.com/llama3_2/license/)) and Acceptable Use Policy ([https://www.llama.com/llama3_2/use-policy/](https://www.llama.com/llama3_2/use-policy/))
+
+Llama is a trademark of Meta Platforms, Inc. "Built with Llama." Use of these models is governed by Meta's license terms linked above.
+
+### Open Source Software Licenses
+
+This app includes open source software components. A complete report of the third-party open source dependencies and their licenses is available here:
+
+<!-- markdown-link-check-disable-next-line -->
+[Open Source License Report](https://app.fossa.com/reports/eb25eabe-7e15-45fb-ac34-b1f1cd848b03)
+
 The datasets used for benchmarking are subject to their original licenses and terms of use. Please consult the documentation of each specific dataset for details on usage rights and restrictions.

--- a/flutter/lib/ui/settings/about_screen.dart
+++ b/flutter/lib/ui/settings/about_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:mlperfbench/localizations/app_localizations.dart';
 
@@ -36,7 +39,14 @@ class _AboutText extends State<AboutText> {
       builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
         Widget child;
         if (snapshot.hasData) {
-          child = Markdown(data: snapshot.data!);
+          child = Markdown(
+            data: snapshot.data!,
+            onTapLink: (text, href, title) {
+              if (href == null) return;
+              final uri = Uri.parse(href);
+              unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
+            },
+          );
         } else if (snapshot.hasError) {
           child = Text('${snapshot.error}');
         } else {


### PR DESCRIPTION
Updates the in-app **About → Licensing Information** section (`flutter/assets/text/about.md`):

- **Large Language Models** subsection — adds the required "Built with Llama" attribution and Meta trademark notice, with links to the Community License Agreements and Acceptable Use Policies for:
  - Llama 3.1 8B-Instruct (Llama 3.1 license)
  - Llama 3.2 3B-Instruct (Llama 3.2 license)
- **Open Source Software Licenses** subsection — links to the FOSSA OSS license report for third-party dependencies.