### PR TITLE
chore: Increase targetSdkVersion from 35 to 36

### DIFF
--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "org.mlcommons.android.mlperfbench"
         minSdkVersion 30
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Google Play requires all apps to target **Android 16 (API level 36)** or higher to remain updatable after **Aug 31, 2026**. This bumps `targetSdkVersion` from 35 to 36. `compileSdk` is already 36, so this is the only change required.

## Risk assessment

Low risk — the app has targeted SDK 35 since #1017 (Jul 2025), so the most disruptive change (edge-to-edge enforcement, introduced at target 35 on Android 15) has already been in production for a year.

- **Edge-to-edge opt-out removed in 36** — N/A; the app never used `windowOptOutEdgeToEdgeEnforcement` and has no custom system-bar colors.
- **JobScheduler quotas / broadcasts / foreground-service types** — N/A; no services, receivers, providers, or alarms in the manifest.
- **16 KB page-size support** — already required at target 35+; native libs are built with NDK 28 + `compileSdk 36` (16 KB-aligned by default).
- **Storage permissions** — already scoped with `maxSdkVersion` (32/29).

* Closes https://github.com/mlcommons/mobile_app_open/issues/1161