### PR TITLE
chore: bump app version to 6.0.1

### DIFF
--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 # version format: <semantic_app_version>+<build_number>.
 # Note: build_number will be set by CI using the CLI option --build-number
-version: 6.0.0+1
+version: 6.0.1+1
 
 environment:
   sdk: ^3.12.0  # Dart SDK version


### PR DESCRIPTION
- Bump app version from `6.0.0` to `6.0.1` in `flutter/pubspec.yaml`