### PR TITLE
fix: let iOS builds without Firebase secrets (use dummy values) + @main migration

### DIFF
--- a/flutter/ios/Runner/AppDelegate.swift
+++ b/flutter/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Flutter
 import UIKit
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/flutter/lib/firebase/firebase_options.template.dart
+++ b/flutter/lib/firebase/firebase_options.template.dart
@@ -9,12 +9,19 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 
 class DefaultFirebaseOptions {
+  // Sentinel injected by flutter/tool/generate-firebase-config-files.sh when
+  // no real Firebase project is configured. Native Firebase needs non-empty,
+  // well-formed options to survive app launch; this value marks them as fake
+  // so the Dart side keeps Firebase disabled.
+  static const dummyProjectId = 'dummy-project';
+
   static bool available() {
     try {
       final currentPlatform = DefaultFirebaseOptions.currentPlatform;
       return currentPlatform.apiKey.isNotEmpty &&
           currentPlatform.appId.isNotEmpty &&
-          currentPlatform.projectId.isNotEmpty;
+          currentPlatform.projectId.isNotEmpty &&
+          currentPlatform.projectId != dummyProjectId;
     } catch (e) {
       return false;
     }

--- a/flutter/tool/generate-firebase-config-files.sh
+++ b/flutter/tool/generate-firebase-config-files.sh
@@ -3,6 +3,14 @@
 
 set -e
 
+# FlutterFire auto-configures Firebase on iOS whenever GoogleService-Info.plist
+# is bundled, and firebase-ios-sdk raises an NSException at launch if
+# GOOGLE_APP_ID is empty or malformed. Builds without Firebase secrets need a
+# well-formed dummy app ID so the app can start; Firebase stays disabled on the
+# Dart side because FIREBASE_IOS_API_KEY is empty
+# (see DefaultFirebaseOptions.available()).
+FIREBASE_IOS_APP_ID="${FIREBASE_IOS_APP_ID:-1:000000000000:ios:0000000000000000}"
+
 files=(
   "flutter/lib/firebase/firebase_options.template.dart:flutter/lib/firebase/firebase_options.gen.dart"
   "flutter/ios/Runner/GoogleService-Info.template.plist:flutter/ios/Runner/GoogleService-Info.plist"

--- a/flutter/tool/generate-firebase-config-files.sh
+++ b/flutter/tool/generate-firebase-config-files.sh
@@ -12,7 +12,9 @@ set -e
 # app can start. The Dart side recognizes the dummy project ID and keeps
 # Firebase disabled (see DefaultFirebaseOptions.available()).
 FIREBASE_IOS_APP_ID="${FIREBASE_IOS_APP_ID:-1:000000000000:ios:0000000000000000}"
-FIREBASE_IOS_API_KEY="${FIREBASE_IOS_API_KEY:-AIzaSyDummyApiKeyForBuildsWithoutFirebase}"
+# FirebaseInstallations requires the API key to be 39 chars, start with "A",
+# and contain only base64 url-safe characters.
+FIREBASE_IOS_API_KEY="${FIREBASE_IOS_API_KEY:-AIzaSyDummyKeyForBuildsWithoutFirebase0}"
 FIREBASE_PROJECT_ID="${FIREBASE_PROJECT_ID:-dummy-project}"
 
 files=(

--- a/flutter/tool/generate-firebase-config-files.sh
+++ b/flutter/tool/generate-firebase-config-files.sh
@@ -4,12 +4,16 @@
 set -e
 
 # FlutterFire auto-configures Firebase on iOS whenever GoogleService-Info.plist
-# is bundled, and firebase-ios-sdk raises an NSException at launch if
-# GOOGLE_APP_ID is empty or malformed. Builds without Firebase secrets need a
-# well-formed dummy app ID so the app can start; Firebase stays disabled on the
-# Dart side because FIREBASE_IOS_API_KEY is empty
-# (see DefaultFirebaseOptions.available()).
+# is bundled, and firebase-ios-sdk kills the app at launch when required options
+# are empty or malformed: FIRApp validates the GOOGLE_APP_ID format, and
+# FirebaseInstallations separately validates API_KEY and PROJECT_ID on app
+# activation.
+# Builds without Firebase secrets need well-formed dummies for all three so the
+# app can start. The Dart side recognizes the dummy project ID and keeps
+# Firebase disabled (see DefaultFirebaseOptions.available()).
 FIREBASE_IOS_APP_ID="${FIREBASE_IOS_APP_ID:-1:000000000000:ios:0000000000000000}"
+FIREBASE_IOS_API_KEY="${FIREBASE_IOS_API_KEY:-AIzaSyDummyApiKeyForBuildsWithoutFirebase}"
+FIREBASE_PROJECT_ID="${FIREBASE_PROJECT_ID:-dummy-project}"
 
 files=(
   "flutter/lib/firebase/firebase_options.template.dart:flutter/lib/firebase/firebase_options.gen.dart"


### PR DESCRIPTION
## What

Lets iOS builds without Firebase secrets launch. The app is designed to run Firebase-free (`FirebaseManager.enabled`), but without secrets the generated `GoogleService-Info.plist` contained empty values, and firebase-ios-sdk kills the app at launch anyway: `FIRApp` rejects an empty/malformed `GOOGLE_APP_ID`, and `FirebaseInstallations` separately validates `APIKey` (exactly 39 chars, leading `A`, base64 url-safe) and `projectID` at app activation — even when Dart never initializes Firebase.

- `generate-firebase-config-files.sh` now defaults `FIREBASE_IOS_APP_ID`, `FIREBASE_IOS_API_KEY`, and `FIREBASE_PROJECT_ID` to well-formed dummies that pass all native validation. Real env values (CI secrets) take precedence.
- `DefaultFirebaseOptions.available()` recognizes the dummy project ID, so Firebase stays disabled on the Dart side.
- Also migrates `AppDelegate` from the deprecated `@UIApplicationMain` to `@main` (the Flutter 3.44 tool auto-applies this on every run, dirtying each developer's tree).
