### PR TITLE
Allow benchmark-set option changes to persist after app closing

### DIFF
--- a/flutter/lib/benchmark/benchmark.dart
+++ b/flutter/lib/benchmark/benchmark.dart
@@ -161,6 +161,16 @@ class BenchmarkSet {
     return availableOptions().length;
   }
 
+  Map<String, bool> optionStateMap() => {
+    for (BenchmarkOption item in availableOptions()) item.id: item.enabled,
+  };
+
+  void applyOptionStateMap(Map<String, bool> inputMap) {
+    for (final entry in inputMap.entries) {
+      optionSets[optionMap[entry.key]!].setOptionTo(entry.key, entry.value);
+    }
+  }
+
   void applyOptions() {
     for (Benchmark benchmark in benchmarks) {
       benchmark.isActive = true;
@@ -268,6 +278,7 @@ class BenchmarkStore {
     required pb.MLPerfConfig appConfig,
     required List<pb.BenchmarkSetting> backendConfig,
     required Map<String, bool> taskSelection,
+    required Map<String, Map<String, bool>> taskSetSelection,
   }) {
     // sort the order of task based on BenchmarkId.allIds
     final List<pb.TaskConfig> sortedTasks = List.from(appConfig.task)
@@ -297,6 +308,13 @@ class BenchmarkStore {
       benchmarkSets.add(
         BenchmarkSet(config: setConfig, allBenchmarks: allBenchmarks),
       );
+    }
+
+    for (final item in benchmarkSets) {
+      final setMap = taskSetSelection[item.config.id];
+      if (setMap != null) {
+        item.applyOptionStateMap(setMap);
+      }
     }
   }
 
@@ -343,6 +361,14 @@ class BenchmarkStore {
     Map<String, bool> result = {};
     for (var item in allBenchmarks) {
       result[item.id] = item.isActive;
+    }
+    return result;
+  }
+
+  Map<String, Map<String, bool>> get setSelection {
+    Map<String, Map<String, bool>> result = {};
+    for (var item in benchmarkSets) {
+      result[item.config.id] = item.optionStateMap();
     }
     return result;
   }

--- a/flutter/lib/benchmark/state.dart
+++ b/flutter/lib/benchmark/state.dart
@@ -236,16 +236,37 @@ class BenchmarkState extends ChangeNotifier {
       }
     }
 
+    Map<String, Map<String, bool>> taskSetSelection = {};
+    if (_store.taskSetSelection.isNotEmpty) {
+      try {
+        final map = jsonDecode(_store.taskSetSelection) as Map<String, dynamic>;
+        for (final kv in map.entries) {
+          final inner = kv.value as Map<String, dynamic>;
+          taskSetSelection[kv.key] = inner.map(
+            (k, v) => MapEntry(k, v as bool),
+          );
+        }
+      } catch (e, t) {
+        print('Task set selection parse fail: $e');
+        print(t);
+      }
+    }
+
     _benchmarkStore = BenchmarkStore(
       appConfig: configManager.decodedConfig,
       backendConfig: backendInfo.settings.benchmarkSetting,
       taskSelection: taskSelection,
+      taskSetSelection: taskSetSelection,
     );
     restoreLastResult();
   }
 
   void saveTaskSelection() {
     _store.taskSelection = jsonEncode(_benchmarkStore.selection);
+  }
+
+  void saveTaskSetSelection() {
+    _store.taskSetSelection = jsonEncode(_benchmarkStore.setSelection);
   }
 
   BenchmarkStateEnum get state {
@@ -372,6 +393,7 @@ class BenchmarkState extends ChangeNotifier {
       value,
     );
     benchmarkSet.applyOptions();
+    saveTaskSetSelection();
     notifyListeners();
   }
 

--- a/flutter/lib/store.dart
+++ b/flutter/lib/store.dart
@@ -105,6 +105,12 @@ class Store extends ChangeNotifier {
     notifyListeners();
   }
 
+  String get taskSetSelection => _getString(StoreConstants.taskSetSelection);
+
+  set taskSetSelection(String value) {
+    _storeFromDisk.setString(StoreConstants.taskSetSelection, value);
+  }
+
   String get taskSelection => _getString(StoreConstants.taskSelection);
 
   set taskSelection(String value) {
@@ -141,6 +147,7 @@ class StoreConstants {
   static const previousAppVersion = 'previous app version';
   static const keepLogs = 'keep_logs';
   static const taskSelection = 'disabled_tasks';
+  static const taskSetSelection = 'disabled_task_sets';
   static const crashlyticsEnabled = 'crashlyticsEnabled';
   static const appLocale = 'app_locale';
 }

--- a/flutter/unit_test/benchmark/benchmark_store_test.dart
+++ b/flutter/unit_test/benchmark/benchmark_store_test.dart
@@ -275,7 +275,8 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1, task2]),
         backends: [coremlBackend(), tfliteBackend()],
-        taskSelection: {}, taskSetSelection: {},
+        taskSelection: {},
+        taskSetSelection: {},
       );
       final task1Benchmark = store.allBenchmarks.firstWhere(
         (e) => e.id == 'task1',
@@ -292,7 +293,8 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1, task2]),
         backends: [coremlBackend(), tfliteBackend2()],
-        taskSelection: {}, taskSetSelection: {},
+        taskSelection: {},
+        taskSetSelection: {},
       );
       // task2 exists only in the tflite backend: present, defaults to tflite
       final task2Benchmark = store.allBenchmarks.firstWhere(
@@ -306,7 +308,8 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlDefaultPolicyBackend(), tfliteBackend()],
-        taskSelection: {}, taskSetSelection: {},
+        taskSelection: {},
+        taskSetSelection: {},
       );
       final benchmark = store.allBenchmarks.single;
       expect(benchmark.backends.map((e) => e.info.libName), [
@@ -320,7 +323,8 @@ void main() {
         final store = BenchmarkStore(
           appConfig: pb.MLPerfConfig(task: [task1, task2]),
           backends: [coremlFillGapsBackend(), tfliteBackendBoth()],
-          taskSelection: {}, taskSetSelection: {},
+          taskSelection: {},
+          taskSetSelection: {},
         );
         // task1 is supported by the vendor: fallback is filtered out
         final task1Benchmark = store.allBenchmarks.firstWhere(
@@ -344,7 +348,8 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlFillGapsBackend(), tfliteBackend()],
         taskSelection: {},
-        backendSelection: {'task1': 'libtflitebackend'}, taskSetSelection: {},
+        backendSelection: {'task1': 'libtflitebackend'},
+        taskSetSelection: {},
       );
       final benchmark = store.allBenchmarks.single;
       expect(benchmark.selectedBackend.info.libName, 'libcoremlbackend');
@@ -354,7 +359,8 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlBackend(), tfliteBackend()],
-        taskSelection: {}, taskSetSelection: {},
+        taskSelection: {},
+        taskSetSelection: {},
       );
       final benchmark = store.allBenchmarks.single;
       expect(benchmark.selectedDelegate.delegateName, 'coreml-delegate');
@@ -373,7 +379,8 @@ void main() {
         backendSelection: {
           'task1': 'libtflitebackend',
           'task2': 'libgonebackend',
-        }, taskSetSelection: {},
+        },
+        taskSetSelection: {},
       );
       final task1Benchmark = store.allBenchmarks.firstWhere(
         (e) => e.id == 'task1',
@@ -389,7 +396,8 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlBackend(), tfliteBackend()],
-        taskSelection: {}, taskSetSelection: {},
+        taskSelection: {},
+        taskSetSelection: {},
       );
       final modes = [BenchmarkRunModeEnum.performanceOnly.performanceRunMode];
       final before = store.listResources(

--- a/flutter/unit_test/benchmark/benchmark_store_test.dart
+++ b/flutter/unit_test/benchmark/benchmark_store_test.dart
@@ -275,7 +275,7 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1, task2]),
         backends: [coremlBackend(), tfliteBackend()],
-        taskSelection: {},
+        taskSelection: {}, taskSetSelection: {},
       );
       final task1Benchmark = store.allBenchmarks.firstWhere(
         (e) => e.id == 'task1',
@@ -292,7 +292,7 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1, task2]),
         backends: [coremlBackend(), tfliteBackend2()],
-        taskSelection: {},
+        taskSelection: {}, taskSetSelection: {},
       );
       // task2 exists only in the tflite backend: present, defaults to tflite
       final task2Benchmark = store.allBenchmarks.firstWhere(
@@ -306,7 +306,7 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlDefaultPolicyBackend(), tfliteBackend()],
-        taskSelection: {},
+        taskSelection: {}, taskSetSelection: {},
       );
       final benchmark = store.allBenchmarks.single;
       expect(benchmark.backends.map((e) => e.info.libName), [
@@ -320,7 +320,7 @@ void main() {
         final store = BenchmarkStore(
           appConfig: pb.MLPerfConfig(task: [task1, task2]),
           backends: [coremlFillGapsBackend(), tfliteBackendBoth()],
-          taskSelection: {},
+          taskSelection: {}, taskSetSelection: {},
         );
         // task1 is supported by the vendor: fallback is filtered out
         final task1Benchmark = store.allBenchmarks.firstWhere(
@@ -344,7 +344,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlFillGapsBackend(), tfliteBackend()],
         taskSelection: {},
-        backendSelection: {'task1': 'libtflitebackend'},
+        backendSelection: {'task1': 'libtflitebackend'}, taskSetSelection: {},
       );
       final benchmark = store.allBenchmarks.single;
       expect(benchmark.selectedBackend.info.libName, 'libcoremlbackend');
@@ -354,7 +354,7 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlBackend(), tfliteBackend()],
-        taskSelection: {},
+        taskSelection: {}, taskSetSelection: {},
       );
       final benchmark = store.allBenchmarks.single;
       expect(benchmark.selectedDelegate.delegateName, 'coreml-delegate');
@@ -373,7 +373,7 @@ void main() {
         backendSelection: {
           'task1': 'libtflitebackend',
           'task2': 'libgonebackend',
-        },
+        }, taskSetSelection: {},
       );
       final task1Benchmark = store.allBenchmarks.firstWhere(
         (e) => e.id == 'task1',
@@ -389,7 +389,7 @@ void main() {
       final store = BenchmarkStore(
         appConfig: pb.MLPerfConfig(task: [task1]),
         backends: [coremlBackend(), tfliteBackend()],
-        taskSelection: {},
+        taskSelection: {}, taskSetSelection: {},
       );
       final modes = [BenchmarkRunModeEnum.performanceOnly.performanceRunMode];
       final before = store.listResources(

--- a/flutter/unit_test/benchmark/benchmark_store_test.dart
+++ b/flutter/unit_test/benchmark/benchmark_store_test.dart
@@ -37,6 +37,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1, task2]),
         backendConfig: [backendSettings1],
         taskSelection: {},
+        taskSetSelection: {},
       );
 
       expect(store.allBenchmarks.length, 1);
@@ -55,6 +56,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task2, task1]),
         backendConfig: [backendSettings1, backendSettings2],
         taskSelection: {},
+        taskSetSelection: {},
       );
 
       expect(store.allBenchmarks.length, 2);
@@ -71,6 +73,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1, task2]),
         backendConfig: [backendSettings1, backendSettings2],
         taskSelection: {task1.id: true, task2.id: false},
+        taskSetSelection: {},
       );
 
       expect(store.allBenchmarks.length, 2);
@@ -83,6 +86,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1]),
         backendConfig: [backendSettings1],
         taskSelection: {task1.id: false},
+        taskSetSelection: {},
       );
 
       final modes = [BenchmarkRunModeEnum.performanceOnly.performanceRunMode];
@@ -98,6 +102,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1]),
         backendConfig: [backendSettings1],
         taskSelection: {},
+        taskSetSelection: {},
       );
 
       final modes = [BenchmarkRunModeEnum.accuracyOnly.accuracyRunMode];
@@ -144,6 +149,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1]),
         backendConfig: [backendSettings1],
         taskSelection: {},
+        taskSetSelection: {},
       );
 
       final modes = [BenchmarkRunModeEnum.performanceOnly.performanceRunMode];
@@ -181,6 +187,7 @@ void main() {
         appConfig: pb.MLPerfConfig(task: [task1]),
         backendConfig: [backendSettings1],
         taskSelection: {},
+        taskSetSelection: {},
       );
 
       final modes = [


### PR DESCRIPTION
This PR makes it so that enabled or disabled options remain that way after closing and re-opening the app.

Closes #1140, #1122, and possibly supersedes #1124