### PR TITLE
chore: stop applying KGP (Kotlin Gradle Plugin) in the app, upgrade wakelock_plus to 1.7.0

### DIFF
--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -1,6 +1,9 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    // Do not apply "kotlin-android" here. The Flutter Gradle Plugin applies KGP
+    // itself, using the version pinned in settings.gradle. Applying it here makes
+    // Flutter warn about migrating to Built-in Kotlin and will break future builds.
+    // https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers
     id "dev.flutter.flutter-gradle-plugin"
     id 'com.google.gms.google-services'
     id 'com.google.firebase.crashlytics'

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -1373,18 +1373,18 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: "824c5bba0f800e86d32e57d3d1843c531f090005cc89d9a837933e6601093d53"
+      sha256: "7253bca0fcf40d8413ddfcf4d2a1fa0a82475e79be25a4f2c564b695c9351486"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.1"
+    version: "1.7.0"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: b13f99e992e7ae6a152e16c5559d3c07ff445b13330192662494e614ca3e7d7b
+      sha256: "0618d1799f0b28bcf98255b4ee8313e6fc4d38589dc4ee5fe5840d57d1aff6da"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
Silences the Kotlin Gradle Plugin warnings Flutter 3.44 prints on every Android build, and removes one of the four plugins responsible.

### What changed

- Dropped `id "kotlin-android"` from `flutter/android/app/build.gradle`. The Flutter Gradle Plugin applies it itself now, and the 3.44 `flutter create` template no longer lists it.
- `settings.gradle` is untouched, so KGP stays pinned at 2.2.20.
- Upgraded `wakelock_plus` 1.6.1 → 1.7.0, which migrated to Built-in Kotlin. Lockfile only — `^1.2.8` already allowed it.

### The four flagged plugins

| Plugin | Status |
| --- | --- |
| `wakelock_plus` | Fixed here |
| `firebase_app_check`, `firebase_storage` | False positives — already guarded behind `agpMajor < 9 \|\| !builtInKotlin`; Flutter's regex detector can't see the guard |
| `desktop_webview_auth` 0.0.16 | No fix exists; transitive via `firebase_ui_auth` → `firebase_ui_oauth`. Needs an upstream issue |

### Review notes

- The full migration (`android.builtInKotlin=true`, `kotlinOptions` → `kotlin.compilerOptions`) needs Flutter 3.47+ / AGP 9. Deferred to the next toolchain bump.
- `:app:kgpVersion` still reports 2.2.20, so we did not silently fall back to the 2.0.0 KGP bundled with the Flutter Gradle Plugin.
- `:app:compileDebugKotlin` is still in the task graph, confirming `kotlin-android` is applied.
- CI green: Build Android app, build-android-apk, both iOS builds, and the on-device runs all pass.
