### PR TITLE
Run stable diffusion on the LiteRT backend

### DIFF
--- a/.github/workflows/android-build-test-linux.yml
+++ b/.github/workflows/android-build-test-linux.yml
@@ -208,10 +208,6 @@ jobs:
         env:
           OFFICIAL_BUILD: false
           PERF_TEST: true
-          # TEMPORARY (revert before merge): run only stable diffusion, to
-          # validate the new LiteRT SD pipeline on one device session while
-          # the BrowserStack parallel budget is contended.
-          BENCHMARK_IDS: "stable_diffusion"
           WITH_TFLITE: 1
           WITH_LITERT: 1
           WITH_PIXEL: 1
@@ -330,23 +326,32 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          # TEMPORARY (revert before merge): only the LiteRT Pixel 10 Pro
-          # entry, so this board needs one BrowserStack session instead of
-          # eight while validating stable diffusion.
+          - backend: "tflite"
+            device: "Samsung Galaxy M32-11.0"
+          - backend: "pixel"
+            device: "Google Pixel 9 Pro-15.0"
           # The integration test overrides the backend selection on this
           # device so every benchmark LiteRT supports runs on it, stable
           # diffusion included; see deviceBackendOverride in
           # flutter/integration_test.
           - backend: "litert"
             device: "Google Pixel 10 Pro-16.0"
+          - backend: "qti"
+            device: "Samsung Galaxy S25 Ultra-15.0"
           # the app fails on these devices with old Android build
           # removing these for now
           # - backend: "qti"
           #  device: "Samsung Galaxy Tab S9-13.0"
           # - backend: "qti"
           #  device: "Samsung Galaxy S23 Ultra-13.0"
-          # TEMPORARY (revert before merge): vendor entries trimmed with the
-          # rest of the matrix for the stable-diffusion validation run.
+          - backend: "samsung"
+            device: "Samsung Galaxy S24-14.0"
+          - backend: "qti"
+            device: "Samsung Galaxy S26 Ultra-16.0" # SM-S948B, Snapdragon
+          - backend: "samsung"
+            device: "Samsung Galaxy S26-16.0" # SM-S942B, Exynos 2600
+          - backend: "mtk"
+            device: "Samsung Galaxy Tab S10 Plus-15.0"
     env:
       GCLOUD_BUCKET_PATH: gs://mobile-app-build-290400_github-actions/build/${{ needs.computed.outputs.build_number }}
       MAIN_APK_NAME: test-main-unified-${{ needs.computed.outputs.build_number }}.apk

--- a/.github/workflows/android-build-test-linux.yml
+++ b/.github/workflows/android-build-test-linux.yml
@@ -391,7 +391,12 @@ jobs:
             ["${{ matrix.device }}"]
         with:
           timeout_minutes: 85
-          max_attempts: 2
+          # BrowserStack refuses the trigger with BROWSERSTACK_ALL_PARALLELS_IN_USE
+          # when the account's session budget is busy, which happens whenever two
+          # boards run at once. Exit 9 is that trigger failure specifically, so
+          # retrying it just waits for a slot; every other failure still fails
+          # fast. 8 attempts x 5 min tolerates a ~40 min queue.
+          max_attempts: 8
           retry_wait_seconds: 300
           retry_on_exit_code: 9
           command: |
@@ -483,7 +488,11 @@ jobs:
             ["${{ matrix.device }}"]
         with:
           timeout_minutes: 60
-          max_attempts: 2
+          # Exit 9 is a BrowserStack trigger failure, which is what
+          # BROWSERSTACK_ALL_PARALLELS_IN_USE produces when the account's
+          # session budget is busy - retrying it just waits for a free slot.
+          # Every other failure still fails fast.
+          max_attempts: 8
           retry_wait_seconds: 300
           retry_on_exit_code: 9
           command: |
@@ -567,7 +576,11 @@ jobs:
             ["${{ matrix.device }}"]
         with:
           timeout_minutes: 60
-          max_attempts: 2
+          # Exit 9 is a BrowserStack trigger failure, which is what
+          # BROWSERSTACK_ALL_PARALLELS_IN_USE produces when the account's
+          # session budget is busy - retrying it just waits for a free slot.
+          # Every other failure still fails fast.
+          max_attempts: 8
           retry_wait_seconds: 300
           retry_on_exit_code: 9
           command: |

--- a/.github/workflows/android-build-test-linux.yml
+++ b/.github/workflows/android-build-test-linux.yml
@@ -208,6 +208,10 @@ jobs:
         env:
           OFFICIAL_BUILD: false
           PERF_TEST: true
+          # TEMPORARY (revert before merge): run only stable diffusion, to
+          # validate the new LiteRT SD pipeline on one device session while
+          # the BrowserStack parallel budget is contended.
+          BENCHMARK_IDS: "stable_diffusion"
           WITH_TFLITE: 1
           WITH_LITERT: 1
           WITH_PIXEL: 1
@@ -326,32 +330,23 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - backend: "tflite"
-            device: "Samsung Galaxy M32-11.0"
-          - backend: "pixel"
-            device: "Google Pixel 9 Pro-15.0"
+          # TEMPORARY (revert before merge): only the LiteRT Pixel 10 Pro
+          # entry, so this board needs one BrowserStack session instead of
+          # eight while validating stable diffusion.
           # The integration test overrides the backend selection on this
           # device so every benchmark LiteRT supports runs on it, stable
           # diffusion included; see deviceBackendOverride in
           # flutter/integration_test.
           - backend: "litert"
             device: "Google Pixel 10 Pro-16.0"
-          - backend: "qti"
-            device: "Samsung Galaxy S25 Ultra-15.0"
           # the app fails on these devices with old Android build
           # removing these for now
           # - backend: "qti"
           #  device: "Samsung Galaxy Tab S9-13.0"
           # - backend: "qti"
           #  device: "Samsung Galaxy S23 Ultra-13.0"
-          - backend: "samsung"
-            device: "Samsung Galaxy S24-14.0"
-          - backend: "qti"
-            device: "Samsung Galaxy S26 Ultra-16.0" # SM-S948B, Snapdragon
-          - backend: "samsung"
-            device: "Samsung Galaxy S26-16.0" # SM-S942B, Exynos 2600
-          - backend: "mtk"
-            device: "Samsung Galaxy Tab S10 Plus-15.0"
+          # TEMPORARY (revert before merge): vendor entries trimmed with the
+          # rest of the matrix for the stable-diffusion validation run.
     env:
       GCLOUD_BUCKET_PATH: gs://mobile-app-build-290400_github-actions/build/${{ needs.computed.outputs.build_number }}
       MAIN_APK_NAME: test-main-unified-${{ needs.computed.outputs.build_number }}.apk

--- a/.github/workflows/android-build-test-linux.yml
+++ b/.github/workflows/android-build-test-linux.yml
@@ -331,9 +331,9 @@ jobs:
           - backend: "pixel"
             device: "Google Pixel 9 Pro-15.0"
           # The integration test overrides the backend selection on this
-          # device so every benchmark LiteRT supports runs on it (stable
-          # diffusion has no LiteRT setting and is skipped there); see
-          # deviceBackendOverride in flutter/integration_test.
+          # device so every benchmark LiteRT supports runs on it, stable
+          # diffusion included; see deviceBackendOverride in
+          # flutter/integration_test.
           - backend: "litert"
             device: "Google Pixel 10 Pro-16.0"
           - backend: "qti"

--- a/.github/workflows/ios-build-test-macos.yml
+++ b/.github/workflows/ios-build-test-macos.yml
@@ -221,7 +221,11 @@ jobs:
             ["${{ matrix.device }}"]
         with:
           timeout_minutes: 60
-          max_attempts: 2
+          # Exit 9 is a BrowserStack trigger failure, which is what
+          # BROWSERSTACK_ALL_PARALLELS_IN_USE produces when the account's
+          # session budget is busy - retrying it just waits for a free slot.
+          # Every other failure still fails fast.
+          max_attempts: 8
           retry_wait_seconds: 300
           retry_on_exit_code: 9
           command: |

--- a/flutter/integration_test/expected_accuracy.dart
+++ b/flutter/integration_test/expected_accuracy.dart
@@ -105,6 +105,7 @@ const Map<String, Interval> _superResolution = {
 // TODO (anhappdev): update expected accuracy for stable diffusion
 const Map<String, Interval> _stableDiffusion = {
   'cpu': Interval(min: 0, max: 1.0),
+  'cpu|LiteRT': Interval(min: 0, max: 1.0),
   'npu': Interval(min: 0, max: 1.0),
   'tpu': Interval(min: 0, max: 1.0),
   'ane|TFLite': Interval(min: 0, max: 1.0),

--- a/flutter/integration_test/expected_throughput.dart
+++ b/flutter/integration_test/expected_throughput.dart
@@ -238,6 +238,7 @@ const Map<String, Map<String, Interval>> _stableDiffusion = {
     _kS10Plus: Interval(min: 0, max: 100),
   },
   _kSamsungBackend: {_kS24: Interval(min: 0, max: 100)},
+  _kLitertBackend: {_kPixel10Pro: Interval(min: 0, max: 100)},
 };
 
 const Map<String, Map<String, Interval>> _imageClassificationOfflineV2 = {

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -132,7 +132,7 @@ void testBenchmark(
     );
     final extendedResult = await getLastResult(tester);
     printResult(extendedResult);
-    checkResult(extendedResult);
+    checkResult(extendedResult, expectAccuracy: runMode.doAccuracyRun);
     await deleteResources(tester);
   });
 }

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -14,11 +14,20 @@ const _runMode = BenchmarkRunModeEnum.integrationTestRun;
 // The LLM accuracy phase evaluates the whole TinyMMLU set, which is far too
 // slow for a CI device session on the CPU path. quickRun keeps the same lite
 // dataset and quick run config but skips the accuracy phase.
-const _llmRunMode = BenchmarkRunModeEnum.quickRun;
+//
+// Stable diffusion needs the same treatment for the same reason, only more so:
+// loadgen ignores min_query_count in accuracy mode and runs the whole set, so
+// the accuracy phase is 150 sequential 20-step generations plus 150 CLIP
+// scoring passes. On the CPU that is hours, and it also pulls the 1.71 GB CLIP
+// ground truth. quickRun keeps the performance phase, which is time-bounded.
+const _quickRunIds = {BenchmarkId.stableDiffusion};
+const _quickRunMode = BenchmarkRunModeEnum.quickRun;
 const _bindingKeepAliveInterval = Duration(seconds: 20);
 
 BenchmarkRunModeEnum _runModeFor(String benchmarkId) =>
-    benchmarkId.startsWith('llm') ? _llmRunMode : _runMode;
+    benchmarkId.startsWith('llm') || _quickRunIds.contains(benchmarkId)
+        ? _quickRunMode
+        : _runMode;
 
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/flutter/integration_test/first_test.dart
+++ b/flutter/integration_test/first_test.dart
@@ -26,8 +26,8 @@ const _bindingKeepAliveInterval = Duration(seconds: 20);
 
 BenchmarkRunModeEnum _runModeFor(String benchmarkId) =>
     benchmarkId.startsWith('llm') || _quickRunIds.contains(benchmarkId)
-        ? _quickRunMode
-        : _runMode;
+    ? _quickRunMode
+    : _runMode;
 
 void main() {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -139,7 +139,13 @@ bool canRunBenchmark(WidgetTester tester, String benchmarkId) {
   );
   if (benchmark == null) return false;
   final selectedLib = benchmark.selectedBackend.info.libName;
-  if (benchmarkId == 'stable_diffusion') {
+  // Stable diffusion has a backend setting only on QTI and LiteRT (CPU,
+  // see litert_settings_android). Every other backend would fall back to
+  // TFLite, which is far too slow for a CI device session. LiteRT is not
+  // short-circuited here: it falls through to the checks below so that,
+  // like the other benchmarks it claims, it runs only where LiteRT is the
+  // primary backend or is pinned via deviceBackendOverride.
+  if (benchmarkId == 'stable_diffusion' && selectedLib != BackendId.litert) {
     return selectedLib == BackendId.qti;
   }
   // The TFLite fallback is now offered alongside vendor backends, so

--- a/flutter/integration_test/utils.dart
+++ b/flutter/integration_test/utils.dart
@@ -326,18 +326,26 @@ void printResult(ExtendedResult extendedResult) {
   }
 }
 
-void checkResult(ExtendedResult extendedResult) {
+// [expectAccuracy] is the run mode's doAccuracyRun: quickRun skips the
+// accuracy phase entirely, so there is no accuracy to check.
+void checkResult(
+  ExtendedResult extendedResult, {
+  required bool expectAccuracy,
+}) {
   for (final benchmarkResult in extendedResult.results) {
     debugPrint('Checking ${benchmarkResult.benchmarkId}');
     expect(benchmarkResult.performanceRun, isNotNull);
     expect(benchmarkResult.performanceRun!.throughput, isNotNull);
 
-    checkAccuracy(benchmarkResult);
+    checkAccuracy(benchmarkResult, expectAccuracy: expectAccuracy);
     checkThroughput(benchmarkResult, extendedResult.environmentInfo);
   }
 }
 
-void checkAccuracy(BenchmarkExportResult benchmarkResult) {
+void checkAccuracy(
+  BenchmarkExportResult benchmarkResult, {
+  required bool expectAccuracy,
+}) {
   var tag = '[benchmarkId: ${benchmarkResult.benchmarkId}';
   final expectedMap = benchmarkExpectedAccuracy[benchmarkResult.benchmarkId];
   expect(
@@ -365,6 +373,11 @@ void checkAccuracy(BenchmarkExportResult benchmarkResult) {
     isNotNull,
     reason: 'missing expected accuracy for $tag',
   );
+
+  if (!expectAccuracy) {
+    debugPrint('Run mode has no accuracy phase; skipping accuracy check.');
+    return;
+  }
 
   final accuracyRun = benchmarkResult.accuracyRun;
   accuracyRun!;

--- a/mobile_back_litert/README.md
+++ b/mobile_back_litert/README.md
@@ -2,13 +2,14 @@
 
 This backend runs all benchmarks on the
 [LiteRT](https://github.com/google-ai-edge/LiteRT) 2.1.5 CompiledModel API:
-the `llm-*` benchmarks on a dedicated LLM pipeline, and the vision/NLP
-benchmarks on a single-model pipeline.
+the `llm-*` benchmarks on a dedicated LLM pipeline, `stable_diffusion` on a
+dedicated stable diffusion pipeline, and the vision/NLP benchmarks on a
+single-model pipeline.
 
 ## Overview
 
-* Android arm64 only. The backend claims the `llm-*` benchmarks and the
-  vision/NLP benchmarks (stable diffusion is not supported yet).
+* Android arm64 only. The backend claims the `llm-*` benchmarks,
+  `stable_diffusion` and the vision/NLP benchmarks.
 * `claim_policy: CLAIM_SHARED`: lower-priority backends (e.g. the TFLite
   fallback) stay selectable next to LiteRT for every claimed benchmark.
 * `llm_pipeline.cc` drives a `litert::CompiledModel` with explicit `TensorBuffer`s
@@ -45,11 +46,15 @@ bazel build -c opt --config=android_arm64 //mobile_back_litert/cpp/backend_liter
 ## Files
 
 * `cpp/backend_litert/litert_c.cc` — MLPerf backend C API implementation and
-  pipeline dispatch (the `pipeline` custom setting selects the LLM pipeline).
+  pipeline dispatch (the `pipeline` custom setting selects the LLM or the
+  stable diffusion pipeline).
 * `cpp/backend_litert/llm_pipeline.h` / `llm_pipeline.cc` — LLM pipeline: tokenizer, prefill, decode, KV cache.
 * `cpp/backend_litert/single_model_pipeline.h` / `single_model_pipeline.cc` — CompiledModel pipeline for the vision/NLP benchmarks.
-* The stable-diffusion sources (`sd_utils.cc`, `stable_diffusion_*.cc`,
-  `embedding_utils.cc`) are imported but not compiled or wired up yet.
+* `cpp/backend_litert/stable_diffusion_pipeline.h` / `stable_diffusion_pipeline.cc`,
+  `stable_diffusion_invoker.*`, `sd_utils.*`, `embedding_utils.*` — stable
+  diffusion pipeline: text encoder, diffusion loop and decoder. It runs on
+  the CPU accelerator; the shipped models are `dynamic_int8` (text encoder,
+  diffusion) and `dynamic_fp16` (decoder) exports aimed at CPU/XNNPACK.
 * `cpp/backend_litert/backend_settings/litert_settings_android.pbtxt` — benchmark settings (models, delegates).
 * `litert_backend.mk` — make variables and the GPU accelerator download.
 

--- a/mobile_back_litert/cpp/backend_litert/BUILD
+++ b/mobile_back_litert/cpp/backend_litert/BUILD
@@ -34,15 +34,23 @@ pbtxt2header(
 cc_library(
     name = "litert_c",
     srcs = [
+        "embedding_utils.cc",
         "litert_c.cc",
         "llm_pipeline.cc",
+        "sd_utils.cc",
         "single_model_pipeline.cc",
+        "stable_diffusion_invoker.cc",
+        "stable_diffusion_pipeline.cc",
     ],
     hdrs = [
+        "embedding_utils.h",
         "litert_settings_android.h",
         "llm_pipeline.h",
         "pipeline.h",
+        "sd_utils.h",
         "single_model_pipeline.h",
+        "stable_diffusion_invoker.h",
+        "stable_diffusion_pipeline.h",
         "thread_pool.h",
     ],
     copts = tflite_copts() + select({

--- a/mobile_back_litert/cpp/backend_litert/backend_settings/litert_settings_android.pbtxt
+++ b/mobile_back_litert/cpp/backend_litert/backend_settings/litert_settings_android.pbtxt
@@ -2,13 +2,13 @@
 # proto-message: BackendSetting
 
 # Every benchmark runs on the LiteRT CompiledModel API: llm-* on the LLM
-# pipeline, the rest on the single-model pipeline. The GPU accelerator is
-# the default (fp32 model exports, automatic CPU fallback); the CPU choice
-# keeps the int8 exports benchmarkable on XNNPACK. NNAPI is not offered:
-# it is deprecated since Android 15 and the CompiledModel NPU path needs
-# vendor SDKs and AOT-compiled models. Lower-priority backends (the TFLite
-# fallback) stay selectable next to it, so users can compare implementations
-# per benchmark. Stable diffusion has no LiteRT setting yet.
+# pipeline, stable_diffusion on the stable diffusion pipeline, the rest on
+# the single-model pipeline. The GPU accelerator is the default (fp32 model
+# exports, automatic CPU fallback); the CPU choice keeps the int8 exports
+# benchmarkable on XNNPACK. NNAPI is not offered: it is deprecated since
+# Android 15 and the CompiledModel NPU path needs vendor SDKs and
+# AOT-compiled models. Lower-priority backends (the TFLite fallback) stay
+# selectable next to it, so users can compare implementations per benchmark.
 claim_policy: CLAIM_SHARED
 
 common_setting {
@@ -170,6 +170,56 @@ benchmark_setting {
   custom_setting {
     id: "shards_num"
     value: "1"
+  }
+}
+
+benchmark_setting {
+  benchmark_id: "stable_diffusion"
+  framework: "LiteRT"
+  # CPU only: the shipped exports are dynamic_int8 (text encoder, diffusion)
+  # and dynamic_fp16 (decoder), aimed at CPU/XNNPACK. A GPU choice would
+  # need dedicated fp32 exports.
+  delegate_choice: {
+    delegate_name: "CPU"
+    accelerator_name: "cpu"
+    accelerator_desc: "CPU"
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/sd_decoder_dynamic_fp16.tflite"
+      model_checksum: "165b70a01643e70a23e5e54a949be306"
+    }
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/sd_diffusion_model_dynamic_int8.tflite"
+      model_checksum: "ccfd761a2f8186c3669948515d40a880"
+    }
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/sd_text_encoder_dynamic_int8.tflite"
+      model_checksum: "b64effb0360f9ea49a117cdaf8a2fbdc"
+    }
+    model_file: {
+      model_path: "https://mobile.mlcommons-storage.org/app-resources/models/v5_0/tflite/timestep_embeddings_data.bin.ts"
+      model_checksum: "798b772155a69de5df44b304327bb3cc"
+    }
+  }
+  delegate_selected: "CPU"
+  custom_setting {
+    id: "pipeline"
+    value: "StableDiffusionPipeline"
+  }
+  custom_setting {
+    id: "text_encoder_filename"
+    value: "sd_text_encoder_dynamic_int8.tflite"
+  }
+  custom_setting {
+    id: "diffusion_model_filename"
+    value: "sd_diffusion_model_dynamic_int8.tflite"
+  }
+  custom_setting {
+    id: "decoder_filename"
+    value: "sd_decoder_dynamic_fp16.tflite"
+  }
+  custom_setting {
+    id: "timestep_embeddings_filename"
+    value: "timestep_embeddings_data.bin.ts"
   }
 }
 

--- a/mobile_back_litert/cpp/backend_litert/embedding_utils.cc
+++ b/mobile_back_litert/cpp/backend_litert/embedding_utils.cc
@@ -10,19 +10,39 @@ bool TsEmbeddingParser::parse_pickle(const std::string& filename) {
   }
 
   // Read timesteps array
-  std::vector<int32_t> timesteps;
-  uint32_t num_timesteps;
-  file.read(reinterpret_cast<char*>(&num_timesteps), sizeof(uint32_t));
-  timesteps.resize(num_timesteps);
-  file.read(reinterpret_cast<char*>(timesteps.data()),
-            num_timesteps * sizeof(int32_t));
+  uint32_t num_timesteps = 0;
+  if (!file.read(reinterpret_cast<char*>(&num_timesteps), sizeof(uint32_t))) {
+    std::cerr << "Failed to read the timestep count from: " << filename
+              << std::endl;
+    return false;
+  }
+  // One entry per diffusion step of a 1000-step schedule; anything outside
+  // that range means this is not a timestep embedding table, and resizing by
+  // it would allocate an absurd amount of memory.
+  if (num_timesteps == 0 || num_timesteps > MAX_TIMESTEPS) {
+    std::cerr << "Implausible timestep count (" << num_timesteps
+              << ") in: " << filename << std::endl;
+    return false;
+  }
+
+  std::vector<int32_t> timesteps(num_timesteps);
+  if (!file.read(reinterpret_cast<char*>(timesteps.data()),
+                 num_timesteps * sizeof(int32_t))) {
+    std::cerr << "Failed to read " << num_timesteps
+              << " timesteps from: " << filename << std::endl;
+    return false;
+  }
 
   // Read embeddings array
   std::vector<std::vector<float>> embeddings(num_timesteps);
   for (auto& emb : embeddings) {
     emb.resize(EMBEDDING_DIM);
-    file.read(reinterpret_cast<char*>(emb.data()),
-              EMBEDDING_DIM * sizeof(float));
+    if (!file.read(reinterpret_cast<char*>(emb.data()),
+                   EMBEDDING_DIM * sizeof(float))) {
+      std::cerr << "Failed to read the timestep embeddings from: " << filename
+                << std::endl;
+      return false;
+    }
   }
 
   // Reverse both timesteps and embeddings before storing
@@ -39,7 +59,8 @@ bool TsEmbeddingParser::parse_pickle(const std::string& filename) {
 std::vector<float> TsEmbeddingParser::get_timestep_embedding(
     int32_t steps, int32_t step_index) const {
   auto emb_it = embeddings_.find(steps);
-  if (emb_it == embeddings_.end() || step_index >= emb_it->second.size()) {
+  if (emb_it == embeddings_.end() || step_index < 0 ||
+      static_cast<size_t>(step_index) >= emb_it->second.size()) {
     return {};
   }
   return emb_it->second[step_index];

--- a/mobile_back_litert/cpp/backend_litert/embedding_utils.h
+++ b/mobile_back_litert/cpp/backend_litert/embedding_utils.h
@@ -2,6 +2,7 @@
 #define EMBEDDING_UTILS_H_
 
 #include <algorithm>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -17,6 +18,9 @@ class TsEmbeddingParser {
 
  private:
   static constexpr size_t EMBEDDING_DIM = 1280;
+  // Upper bound on the timestep count read from the file, used as a sanity
+  // check before anything is resized by it.
+  static constexpr uint32_t MAX_TIMESTEPS = 1000;
   std::map<int32_t, std::vector<int32_t>> timesteps_;
   std::map<int32_t, std::vector<std::vector<float>>> embeddings_;
 };

--- a/mobile_back_litert/cpp/backend_litert/litert_c.cc
+++ b/mobile_back_litert/cpp/backend_litert/litert_c.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "litert_settings_android.h"
 #include "llm_pipeline.h"
 #include "single_model_pipeline.h"
+#include "stable_diffusion_pipeline.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,8 +25,9 @@ extern "C" {
 std::unique_ptr<Pipeline> pipeline;
 
 // This backend is Android-only. The llm-* benchmarks run on the LiteRT
-// CompiledModel LLM pipeline; every other benchmark runs on the CompiledModel
-// single-model pipeline (GPU accelerator with CPU fallback).
+// CompiledModel LLM pipeline, stable_diffusion runs on the CompiledModel
+// stable diffusion pipeline (CPU), and every other benchmark runs on the
+// CompiledModel single-model pipeline (GPU accelerator with CPU fallback).
 bool mlperf_backend_matches_hardware(const char **not_allowed_message,
                                      const char **settings,
                                      const mlperf_device_info_t *device_info) {
@@ -60,13 +62,16 @@ mlperf_backend_ptr_t mlperf_backend_create(
   if (strcmp(pipeline_type, "LLMPipeline") == 0) {
     LOG(INFO) << "Initializing LLMPipeline";
     pipeline = std::make_unique<LLMPipeline>();
+  } else if (strcmp(pipeline_type, "StableDiffusionPipeline") == 0) {
+    LOG(INFO) << "Initializing StableDiffusionPipeline";
+    pipeline = std::make_unique<StableDiffusionPipeline>();
   } else if (strcmp(pipeline_type, "") == 0 ||
              strcmp(pipeline_type, "SingleModelPipeline") == 0) {
     LOG(INFO) << "Initializing SingleModelPipeline";
     pipeline = std::make_unique<SingleModelPipeline>();
   } else {
-    // Fail loudly on settings imported from another backend (e.g.
-    // StableDiffusionPipeline) instead of feeding them to the wrong pipeline.
+    // Fail loudly on settings imported from another backend instead of
+    // feeding them to the wrong pipeline.
     LOG(ERROR) << "Unsupported pipeline: " << pipeline_type;
     return nullptr;
   }

--- a/mobile_back_litert/cpp/backend_litert/sd_utils.cc
+++ b/mobile_back_litert/cpp/backend_litert/sd_utils.cc
@@ -1,5 +1,7 @@
 #include "sd_utils.h"
 
+#include "absl/log/log.h"
+
 std::vector<int> get_timesteps(int start, int stop, int delta) {
   std::vector<int> timesteps;
   for (int i = start; i < stop; i += delta) {
@@ -216,50 +218,16 @@ std::tuple<std::vector<float>, std::vector<float>> get_initial_alphas(
 
   alphas_prev.push_back(1.0);
   for (auto i = timesteps.begin(); i < timesteps.end(); i++) {
+    // A timestep outside the cumulative alpha table means the schedule does
+    // not belong to this model; return empty vectors so the caller fails
+    // instead of reading past the table.
+    if (*i < 0 || static_cast<size_t>(*i) >= alpha_cum.size()) {
+      LOG(ERROR) << "Timestep " << *i << " is outside the alpha table of "
+                 << alpha_cum.size() << " entries";
+      return make_tuple(std::vector<float>(), std::vector<float>());
+    }
     alphas.push_back(alpha_cum[*i]);
     if (i < timesteps.end() - 1) alphas_prev.push_back(alpha_cum[*i]);
   }
   return make_tuple(alphas, alphas_prev);
 }
-
-std::vector<float> get_timestep_embedding(int timestep, int batch_size, int dim,
-                                          int max_period) {
-  std::vector<float> embedding_cos;
-  std::vector<float> embedding_sin;
-
-  auto half = dim / 2;
-  for (int i = 0; i < half; i++) {
-    auto freq = expf(-logf(max_period) * i / half);
-    embedding_cos.push_back(cosf(timestep * freq));
-    embedding_sin.push_back(sinf(timestep * freq));
-  }
-  std::vector<float> embedding;
-  for (int i = 0; i < batch_size; i++) {
-    embedding.insert(embedding.end(),
-                     std::make_move_iterator(embedding_cos.begin()),
-                     std::make_move_iterator(embedding_cos.end()));
-    embedding.insert(embedding.end(),
-                     std::make_move_iterator(embedding_sin.begin()),
-                     std::make_move_iterator(embedding_sin.end()));
-  }
-
-  // std::cout << "embedding.size(): " << embedding.size() << "\n";
-  return embedding;
-}
-
-#ifdef __TEST_BPE__
-int main(int argc, char *argv[]) {
-  int num_steps = 30;
-  auto timesteps = get_timesteps(1, 1000, 1000 / num_steps);
-  auto as = get_initial_alphas(timesteps);
-  auto len = std::get<0>(as).size();
-  for (int i = 0; i < len; i++) {
-    std::cout << std::get<0>(as)[i] << ", " << std::get<1>(as)[i] << "\n";
-  }
-  auto e = get_timestep_embedding(801);
-  for (int i = 0; i < 16; i++) {
-    std::cout << e[i] << "\t";
-  }
-  std::cout << "\n";
-}
-#endif

--- a/mobile_back_litert/cpp/backend_litert/sd_utils.h
+++ b/mobile_back_litert/cpp/backend_litert/sd_utils.h
@@ -10,8 +10,5 @@
 std::vector<int> get_timesteps(int start, int stop, int delta);
 std::tuple<std::vector<float>, std::vector<float>> get_initial_alphas(
     std::vector<int> timesteps);
-std::vector<float> get_timestep_embedding(int timestep, int batch_size = 1,
-                                          int dim = 320,
-                                          int max_period = 10000);
 
 #endif

--- a/mobile_back_litert/cpp/backend_litert/stable_diffusion_invoker.cc
+++ b/mobile_back_litert/cpp/backend_litert/stable_diffusion_invoker.cc
@@ -1,14 +1,40 @@
+/* Copyright 2024 The MLPerf Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 #include "stable_diffusion_invoker.h"
 
-#include <iostream>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
 #include <random>
+#include <tuple>
 #include <valarray>
+#include <vector>
 
+#include "absl/log/log.h"
 #include "embedding_utils.h"
+#include "litert/cc/litert_tensor_buffer.h"
 #include "sd_utils.h"
-#include "stable_diffusion_pipeline.h"
-#include "tflite/c/c_api.h"
-#include "tflite/c/common.h"
+
+namespace {
+
+// All three Stable Diffusion models export exactly one signature.
+constexpr size_t kSignatureIndex = 0;
+
+// Latent resolution of the 512x512 UNet: 64 * 64 * 4.
+constexpr unsigned kLatentElements = 64 * 64 * 4;
+
+// Classifier-free guidance scale of the reference implementation.
+constexpr float kUnconditionalGuidanceScale = 7.5f;
 
 std::vector<float> get_normal(unsigned numbers, unsigned seed = 5,
                               float mean = 0.0, float stddev = 1.0) {
@@ -21,130 +47,190 @@ std::vector<float> get_normal(unsigned numbers, unsigned seed = 5,
   return d;
 }
 
-StableDiffusionInvoker::StableDiffusionInvoker(SDBackendData* backend_data)
+// Writes a host vector into a tensor buffer. TensorBuffer::Write only fails
+// when the source is *larger* than the tensor, so the exact-size check has
+// to happen here: a short write would silently leave the tail of the tensor
+// holding the previous invocation's data.
+template <typename T>
+bool WriteExact(litert::TensorBuffer &buffer, const std::vector<T> &data,
+                const char *what) {
+  auto packed = buffer.PackedSize();
+  if (!packed) {
+    LOG(ERROR) << "PackedSize failed for " << what << ": "
+               << packed.Error().Message();
+    return false;
+  }
+  if (*packed != data.size() * sizeof(T)) {
+    LOG(ERROR) << "Cannot write " << what << ": the tensor holds " << *packed
+               << " bytes, got " << data.size() * sizeof(T);
+    return false;
+  }
+  auto written =
+      buffer.Write<T>(litert::Span<const T>(data.data(), data.size()));
+  if (!written) {
+    LOG(ERROR) << "Failed to write " << what << ": "
+               << written.Error().Message();
+    return false;
+  }
+  return true;
+}
+
+// Reads a float tensor into *out, sized from the buffer's packed size. The
+// model's own shapes are no help here: they are dynamic in dim 0, and
+// RankedTensorType::Bytes()/NumElements() fail on dynamic dimensions.
+bool ReadFloats(litert::TensorBuffer &buffer, std::vector<float> *out,
+                const char *what) {
+  auto packed = buffer.PackedSize();
+  if (!packed) {
+    LOG(ERROR) << "PackedSize failed for " << what << ": "
+               << packed.Error().Message();
+    return false;
+  }
+  if (*packed == 0 || *packed % sizeof(float) != 0) {
+    LOG(ERROR) << "Unusable size for " << what << ": " << *packed << " bytes";
+    return false;
+  }
+  out->resize(*packed / sizeof(float));
+  auto read = buffer.Read<float>(litert::Span<float>(out->data(), out->size()));
+  if (!read) {
+    LOG(ERROR) << "Failed to read " << what << ": " << read.Error().Message();
+    return false;
+  }
+  return true;
+}
+
+// Run is synchronous; the buffers were created once at backend_create time.
+bool RunModel(SDModel &model, const char *what) {
+  auto run =
+      model.compiled->Run(kSignatureIndex, model.input_bufs, model.output_bufs);
+  if (!run) {
+    LOG(ERROR) << "Failed to run the " << what << ": " << run.Error().Message();
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+StableDiffusionInvoker::StableDiffusionInvoker(SDBackendData *backend_data)
     : backend_data_(backend_data) {}
 
-std::vector<float> StableDiffusionInvoker::invoke() {
+bool StableDiffusionInvoker::invoke(std::vector<float> *image) {
   LOG(INFO) << "Prompt encoding started";
-  auto encoded_text = encode_prompt(backend_data_->input_prompt_tokens);
-  auto unconditional_encoded_text =
-      encode_prompt(backend_data_->unconditional_tokens);
+  std::vector<float> encoded_text;
+  if (!encode_prompt(backend_data_->input_prompt_tokens, &encoded_text)) {
+    return false;
+  }
+  std::vector<float> unconditional_encoded_text;
+  if (!encode_prompt(backend_data_->unconditional_tokens,
+                     &unconditional_encoded_text)) {
+    return false;
+  }
+
   LOG(INFO) << "Diffusion process started";
-  auto latent =
-      diffusion_process(encoded_text, unconditional_encoded_text,
-                        backend_data_->num_steps, backend_data_->seed);
+  std::vector<float> latent;
+  if (!diffusion_process(encoded_text, unconditional_encoded_text,
+                         backend_data_->num_steps, backend_data_->seed,
+                         &latent)) {
+    return false;
+  }
+
   LOG(INFO) << "Image decoding started";
-  return decode_image(latent);
+  return decode_image(latent, image);
 }
 
-std::vector<float> StableDiffusionInvoker::encode_prompt(
-    const std::vector<int>& data) {
-  return run_inference(backend_data_->text_encoder_interpreter, data);
-}
+bool StableDiffusionInvoker::encode_prompt(const std::vector<int32_t> &tokens,
+                                           std::vector<float> *context) {
+  SDModel &model = backend_data_->text_encoder;
 
-std::vector<float> StableDiffusionInvoker::diffusion_step(
-    const std::vector<float>& latent, const std::vector<float>& t_emb,
-    const std::vector<float>& context) {
-  auto latent_input_details =
-      TfLiteInterpreterGetInputTensor(backend_data_->sd_interpreter, 0);
-  auto context_input_details =
-      TfLiteInterpreterGetInputTensor(backend_data_->sd_interpreter, 1);
-  auto time_stamp_embedding_input_details =
-      TfLiteInterpreterGetInputTensor(backend_data_->sd_interpreter, 2);
-
-  std::copy(context.begin(), context.end(),
-            reinterpret_cast<float*>(TfLiteTensorData(context_input_details)));
-  std::copy(t_emb.begin(), t_emb.end(),
-            reinterpret_cast<float*>(
-                TfLiteTensorData(time_stamp_embedding_input_details)));
-  std::copy(latent.begin(), latent.end(),
-            reinterpret_cast<float*>(TfLiteTensorData(latent_input_details)));
-
-  // Invoke the model
-  if (TfLiteInterpreterInvoke(backend_data_->sd_interpreter) != kTfLiteOk) {
-    std::cerr << "Failed to invoke the first diffusion model!" << std::endl;
-    exit(-1);
+  // Position ids run 0..76 alongside the token ids.
+  std::vector<int32_t> positions(tokens.size());
+  for (size_t i = 0; i < positions.size(); ++i) {
+    positions[i] = static_cast<int32_t>(i);
   }
 
-  float* output = reinterpret_cast<float*>(TfLiteTensorData(
-      TfLiteInterpreterGetOutputTensor(backend_data_->sd_interpreter, 0)));
-  int output_size = TfLiteTensorByteSize(TfLiteInterpreterGetOutputTensor(
-                        backend_data_->sd_interpreter, 0)) /
-                    sizeof(float);
-  return std::vector<float>(output, output + output_size);
-}
-
-// Helper function to get tensor index by name
-int StableDiffusionInvoker::get_tensor_index_by_name(
-    TfLiteInterpreter* interpreter, const std::string& name, bool is_input) {
-  int tensor_count = is_input
-                         ? TfLiteInterpreterGetInputTensorCount(interpreter)
-                         : TfLiteInterpreterGetOutputTensorCount(interpreter);
-
-  for (int i = 0; i < tensor_count; ++i) {
-    const char* tensor_name =
-        is_input
-            ? TfLiteTensorName(TfLiteInterpreterGetInputTensor(interpreter, i))
-            : TfLiteTensorName(
-                  TfLiteInterpreterGetOutputTensor(interpreter, i));
-
-    if (tensor_name == name) {
-      return i;
-    }
+  if (!WriteExact(model.input_bufs[backend_data_->encoder_tokens_idx], tokens,
+                  "text encoder tokens") ||
+      !WriteExact(model.input_bufs[backend_data_->encoder_positions_idx],
+                  positions, "text encoder positions")) {
+    return false;
   }
-  return -1;
+  if (!RunModel(model, "text encoder")) return false;
+  return ReadFloats(model.output_bufs[model.output_idx], context,
+                    "text encoder output");
 }
 
-std::vector<float> StableDiffusionInvoker::diffusion_process(
-    const std::vector<float>& encoded_text,
-    const std::vector<float>& unconditional_encoded_text, int num_steps,
-    int seed) {
-  float unconditional_guidance_scale = 7.5f;
+bool StableDiffusionInvoker::diffusion_step(const std::vector<float> &latent,
+                                            const std::vector<float> &t_emb,
+                                            const std::vector<float> &context,
+                                            std::vector<float> *noise) {
+  SDModel &model = backend_data_->diffusion;
 
-  auto noise = get_normal(64 * 64 * 4, seed);
-  auto latent = noise;
+  if (!WriteExact(model.input_bufs[backend_data_->diffusion_latent_idx], latent,
+                  "diffusion latent") ||
+      !WriteExact(model.input_bufs[backend_data_->diffusion_context_idx],
+                  context, "diffusion context") ||
+      !WriteExact(model.input_bufs[backend_data_->diffusion_timestep_idx],
+                  t_emb, "diffusion timestep embedding")) {
+    return false;
+  }
+  if (!RunModel(model, "diffusion model")) return false;
+  return ReadFloats(model.output_bufs[model.output_idx], noise,
+                    "diffusion model output");
+}
+
+bool StableDiffusionInvoker::diffusion_process(
+    const std::vector<float> &encoded_text,
+    const std::vector<float> &unconditional_encoded_text, int num_steps,
+    int seed, std::vector<float> *out_latent) {
+  auto latent = get_normal(kLatentElements, seed);
 
   // Get pre-calculated timesteps and embeddings
-  auto& embedding_manager = EmbeddingManager::getInstance();
+  auto &embedding_manager = EmbeddingManager::getInstance();
   auto timesteps = embedding_manager.get_timesteps(num_steps);
-
   if (timesteps.empty()) {
     LOG(ERROR) << "Failed to get timesteps for " << num_steps << " steps";
-    return std::vector<float>();
+    return false;
   }
 
   auto alphas_tuple = get_initial_alphas(timesteps);
+  const auto &alphas = std::get<0>(alphas_tuple);
+  const auto &alphas_prev = std::get<1>(alphas_tuple);
+  // get_initial_alphas returns empty schedules when a timestep falls outside
+  // the cumulative alpha table.
+  if (alphas.size() != timesteps.size() ||
+      alphas_prev.size() != timesteps.size()) {
+    LOG(ERROR) << "Failed to build the alpha schedule for " << num_steps
+               << " steps";
+    return false;
+  }
 
-  auto alphas = std::get<0>(alphas_tuple);
-  auto alphas_prev = std::get<1>(alphas_tuple);
-
-  for (int i = timesteps.size() - 1; i >= 0; --i) {
+  for (int i = static_cast<int>(timesteps.size()) - 1; i >= 0; --i) {
     LOG(INFO) << "Step " << timesteps.size() - 1 - i;
 
-    auto latent_prev = latent;
-
     auto t_emb = embedding_manager.get_timestep_embedding(i, num_steps);
-
     if (t_emb.empty()) {
-      LOG(ERROR) << "Failed to get timestamp embedding for step " << i;
-      return std::vector<float>();
+      LOG(ERROR) << "Failed to get the timestep embedding for step " << i;
+      return false;
     }
 
-    if (t_emb.empty()) {
-      LOG(ERROR) << "Failed to get timestamp embedding for step " << i;
-      return std::vector<float>();
+    std::vector<float> unconditional_latent;
+    std::vector<float> conditional_latent;
+    if (!diffusion_step(latent, t_emb, unconditional_encoded_text,
+                        &unconditional_latent) ||
+        !diffusion_step(latent, t_emb, encoded_text, &conditional_latent)) {
+      return false;
     }
 
-    auto unconditional_latent =
-        diffusion_step(latent, t_emb, unconditional_encoded_text);
-    latent = diffusion_step(latent, t_emb, encoded_text);
-
-    std::valarray<float> l(latent.data(), latent.size());
-    std::valarray<float> l_prev(latent_prev.data(), latent_prev.size());
+    std::valarray<float> l(conditional_latent.data(),
+                           conditional_latent.size());
+    // latent still holds this step's input; the DDIM update below replaces
+    // it with the next one.
+    std::valarray<float> l_prev(latent.data(), latent.size());
     std::valarray<float> u(unconditional_latent.data(),
                            unconditional_latent.size());
 
-    l = u + unconditional_guidance_scale * (l - u);
+    l = u + kUnconditionalGuidanceScale * (l - u);
 
     auto a_t = alphas[i];
     auto a_prev = alphas_prev[i];
@@ -155,91 +241,19 @@ std::vector<float> StableDiffusionInvoker::diffusion_process(
   }
 
   LOG(INFO) << "Diffusion process completed!";
-  return latent;
+  *out_latent = std::move(latent);
+  return true;
 }
 
-std::vector<float> StableDiffusionInvoker::decode_image(
-    const std::vector<float>& latent) {
-  return run_inference(backend_data_->decoder_interpreter, latent);
-}
+bool StableDiffusionInvoker::decode_image(const std::vector<float> &latent,
+                                          std::vector<float> *image) {
+  SDModel &model = backend_data_->decoder;
 
-std::vector<float> StableDiffusionInvoker::run_inference(
-    TfLiteInterpreter* interpreter, const std::vector<int>& encoded) {
-  // Determine the size of the encoded input
-  int encoded_size = encoded.size();
-
-  // Generate position IDs corresponding to the length of the encoded tokens
-  std::vector<int> pos_ids(encoded_size);
-  for (int i = 0; i < encoded_size; ++i) {
-    pos_ids[i] = i;  // Position ID corresponds to the index
+  if (!WriteExact(model.input_bufs[backend_data_->decoder_latent_idx], latent,
+                  "decoder latent")) {
+    return false;
   }
-
-  // Access the input tensors
-  void* pos_ids_input_data =
-      TfLiteTensorData(TfLiteInterpreterGetInputTensor(interpreter, 1));
-  void* encoded_input_data =
-      TfLiteTensorData(TfLiteInterpreterGetInputTensor(interpreter, 0));
-
-  // Copy data to input tensors (type cast required for correct copy operation)
-  std::memcpy(pos_ids_input_data, pos_ids.data(), pos_ids.size() * sizeof(int));
-  std::memcpy(encoded_input_data, encoded.data(), encoded.size() * sizeof(int));
-
-  // Invoke the model
-  if (TfLiteInterpreterInvoke(interpreter) != kTfLiteOk) {
-    std::cerr << "Failed to invoke LiteRT!" << std::endl;
-    exit(-1);
-  }
-
-  // Access the output tensor
-  const TfLiteTensor* output_tensor =
-      TfLiteInterpreterGetOutputTensor(interpreter, 0);
-  void* output_data = TfLiteTensorData(output_tensor);
-
-  // Calculate the number of elements in the output tensor
-  int output_size = TfLiteTensorByteSize(output_tensor) / sizeof(float);
-
-  // Cast output_data back to the correct type and return as a vector of floats
-  float* output = static_cast<float*>(output_data);
-  return std::vector<float>(output, output + output_size);
-}
-
-std::vector<float> StableDiffusionInvoker::run_inference(
-    TfLiteInterpreter* interpreter, const std::vector<float>& input) {
-  std::copy(input.begin(), input.end(),
-            reinterpret_cast<float*>(TfLiteTensorData(
-                TfLiteInterpreterGetInputTensor(interpreter, 0))));
-
-  if (TfLiteInterpreterInvoke(interpreter) != kTfLiteOk) {
-    std::cerr << "Failed to invoke the model!" << std::endl;
-    exit(-1);
-  }
-
-  float* output = reinterpret_cast<float*>(
-      TfLiteTensorData(TfLiteInterpreterGetOutputTensor(interpreter, 0)));
-  int output_size =
-      TfLiteTensorByteSize(TfLiteInterpreterGetOutputTensor(interpreter, 0)) /
-      sizeof(float);
-  return std::vector<float>(output, output + output_size);
-}
-
-std::vector<float> StableDiffusionInvoker::get_timestep_embedding(
-    int timestep, int dim, float max_period) {
-  int half = dim / 2;
-  std::vector<float> freqs(half);
-  for (int i = 0; i < half; ++i) {
-    freqs[i] = std::exp(-std::log(max_period) * i / half);
-  }
-
-  std::vector<float> args(half);
-  for (int i = 0; i < half; ++i) {
-    args[i] = timestep * freqs[i];
-  }
-
-  std::vector<float> embedding(2 * half);
-  for (int i = 0; i < half; ++i) {
-    embedding[i] = std::cos(args[i]);
-    embedding[half + i] = std::sin(args[i]);
-  }
-
-  return embedding;
+  if (!RunModel(model, "decoder")) return false;
+  return ReadFloats(model.output_bufs[model.output_idx], image,
+                    "decoder output");
 }

--- a/mobile_back_litert/cpp/backend_litert/stable_diffusion_invoker.h
+++ b/mobile_back_litert/cpp/backend_litert/stable_diffusion_invoker.h
@@ -1,46 +1,57 @@
-#ifndef STABLE_DIFFUSION_INVOKER_H
-#define STABLE_DIFFUSION_INVOKER_H
+/* Copyright 2024 The MLPerf Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 
-#include <memory>
-#include <string>
+#ifndef LITERT_STABLE_DIFFUSION_INVOKER_H_
+#define LITERT_STABLE_DIFFUSION_INVOKER_H_
+
+#include <cstdint>
 #include <vector>
 
 #include "stable_diffusion_pipeline.h"
-#include "tflite/interpreter.h"
-#include "tflite/model_builder.h"
 
+// Runs the encode / denoise / decode sequence for a single prompt over the
+// compiled models held by SDBackendData. Cheap to construct: it owns no
+// LiteRT state, the buffers all live in the backend data.
 class StableDiffusionInvoker {
  public:
-  // Constructor that takes the backend data
-  StableDiffusionInvoker(SDBackendData* backend_data);
+  explicit StableDiffusionInvoker(SDBackendData *backend_data);
 
-  // The main method to invoke the Stable Diffusion process
-  std::vector<float> invoke();
+  // Runs the full pipeline for the currently set prompt and writes the
+  // decoded 512x512x3 image into *image. Returns false on any failure; the
+  // caller reports that as MLPERF_FAILURE.
+  bool invoke(std::vector<float> *image);
 
  private:
-  // Helper methods to encapsulate different stages of the pipeline
-  std::vector<float> encode_prompt(const std::vector<int>& prompt);
-  std::vector<float> diffusion_step(const std::vector<float>& latent,
-                                    const std::vector<float>& t_emb,
-                                    const std::vector<float>& context);
-  std::vector<float> diffusion_process(
-      const std::vector<float>& encoded_text,
-      const std::vector<float>& unconditional_encoded_text, int num_steps,
-      int seed);
-  int get_tensor_index_by_name(TfLiteInterpreter* interpreter,
-                               const std::string& name, bool is_input);
-  std::vector<float> decode_image(const std::vector<float>& latent);
+  // Runs the text encoder over a 77-token prompt.
+  bool encode_prompt(const std::vector<int32_t> &tokens,
+                     std::vector<float> *context);
 
-  // Utility methods
-  std::vector<float> run_inference(TfLiteInterpreter* interpreter,
-                                   const std::vector<int>& encoded);
-  std::vector<float> run_inference(TfLiteInterpreter* interpreter,
-                                   const std::vector<float>& input);
-  std::vector<float> get_timestep_embedding(int timestep, int dim = 320,
-                                            float max_period = 10000.0f);
+  // Runs the diffusion model once, predicting the noise in `latent`.
+  bool diffusion_step(const std::vector<float> &latent,
+                      const std::vector<float> &t_emb,
+                      const std::vector<float> &context,
+                      std::vector<float> *noise);
 
-  // Reference to the backend data structure containing models and interpreters
-  SDBackendData* backend_data_;
+  // Classifier-free guided DDIM sampling loop.
+  bool diffusion_process(const std::vector<float> &encoded_text,
+                         const std::vector<float> &unconditional_encoded_text,
+                         int num_steps, int seed, std::vector<float> *latent);
+
+  // Runs the decoder, turning the final latent into an RGB image.
+  bool decode_image(const std::vector<float> &latent,
+                    std::vector<float> *image);
+
+  // Not owned; outlives the invoker.
+  SDBackendData *backend_data_;
 };
 
-#endif  // STABLE_DIFFUSION_INVOKER_H
+#endif  // LITERT_STABLE_DIFFUSION_INVOKER_H_

--- a/mobile_back_litert/cpp/backend_litert/stable_diffusion_pipeline.cc
+++ b/mobile_back_litert/cpp/backend_litert/stable_diffusion_pipeline.cc
@@ -1,318 +1,521 @@
+/* Copyright 2024 The MLPerf Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 #include "stable_diffusion_pipeline.h"
 
-#include <fstream>
-#include <iostream>
-#include <random>
-#include <valarray>
+#include <algorithm>
+#include <cerrno>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "absl/log/log.h"
 #include "embedding_utils.h"
-#include "flutter/cpp/c/backend_c.h"
-#include "flutter/cpp/utils.h"
+#include "litert/cc/litert_options.h"
 #include "stable_diffusion_invoker.h"
-#include "tflite/c/c_api.h"
-#include "tflite/c/common.h"
-#include "thread_pool.h"
-#include "utils.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif  // __cplusplus
+namespace {
 
-static bool backendExists = false;
+// All three Stable Diffusion models export exactly one signature.
+constexpr size_t kSignatureIndex = 0;
 
-inline mlperf_data_t::Type TfType2Type(TfLiteType type) {
-  switch (type) {
-    case kTfLiteFloat32:
-      return mlperf_data_t::Float32;
-    case kTfLiteUInt8:
-      return mlperf_data_t::Uint8;
-    case kTfLiteInt8:
-      return mlperf_data_t::Int8;
-    case kTfLiteFloat16:
-      return mlperf_data_t::Float16;
-    case kTfLiteInt32:
-      return mlperf_data_t::Int32;
-    case kTfLiteInt64:
-      return mlperf_data_t::Int64;
-    default:
-      LOG(ERROR) << "TfLiteType " << type << " is not supported";
-      return mlperf_data_t::Float32;
+// CLIP prompt length, and the size of the decoded RGB image.
+constexpr int kTokenCount = 77;
+constexpr int kImageElements = 512 * 512 * 3;
+
+// Start-of-text / end-of-text ids of the CLIP BPE vocabulary. The
+// unconditional prompt is a start token followed by padding.
+constexpr int32_t kStartOfTextToken = 49406;
+constexpr int32_t kEndOfTextToken = 49407;
+
+// Every tensor this pipeline binds is int32 or float32, and none is
+// quantized at the graph boundary (all quantization parameters are (0, 0)),
+// so element size is uniform.
+constexpr size_t kElementBytes = 4;
+
+// A tensor bound by name, with the concrete shape it is resized to. Only the
+// batch dimension is dynamic in the exported models.
+struct TensorSpec {
+  const char *name;
+  std::vector<int> dims;
+};
+
+bool backendExists = false;
+
+// The //flutter/cpp:utils config readers are deliberately not linked into
+// this backend (they drag in a second copy of the TF Lite C API), so the two
+// cases this pipeline needs are inlined here.
+int GetConfigInt(mlperf_backend_configuration_t *configs, const char *key,
+                 int default_value) {
+  for (int i = 0; i < configs->count; ++i) {
+    if (strcmp(configs->keys[i], key) != 0) continue;
+    const char *value_str = configs->values[i];
+    char *endptr = nullptr;
+    errno = 0;
+    long value = strtol(value_str, &endptr, 10);
+    if (errno == ERANGE || value < INT_MIN || value > INT_MAX ||
+        endptr == value_str || *endptr != '\0') {
+      LOG(ERROR) << "Invalid int value for " << key << ": " << value_str;
+      return default_value;
+    }
+    return static_cast<int>(value);
   }
+  return default_value;
 }
 
-// Add definition for LiteRTNumElements
-size_t LiteRTNumElements(const TfLiteTensor* tensor) {
-  size_t result = 1;
-  for (int i = 0; i < TfLiteTensorNumDims(tensor); ++i) {
-    result *= TfLiteTensorDim(tensor, i);
+std::string GetConfigString(mlperf_backend_configuration_t *configs,
+                            const char *key, const std::string &default_value) {
+  for (int i = 0; i < configs->count; ++i) {
+    if (strcmp(configs->keys[i], key) == 0) {
+      return std::string(configs->values[i]);
+    }
   }
-  return result;
+  return default_value;
 }
 
+size_t ElementCount(const std::vector<int> &dims) {
+  size_t count = 1;
+  for (int dim : dims) count *= static_cast<size_t>(dim);
+  return count;
+}
+
+std::unordered_map<std::string, size_t> MakeIndexMap(
+    const std::vector<litert::StringView> &names) {
+  std::unordered_map<std::string, size_t> map;
+  for (size_t i = 0; i < names.size(); ++i) map[std::string(names[i])] = i;
+  return map;
+}
+
+std::string JoinNames(const std::vector<litert::StringView> &names) {
+  std::string joined;
+  for (const auto &name : names) {
+    if (!joined.empty()) joined += ", ";
+    joined += std::string(name);
+  }
+  return joined;
+}
+
+// Binds one role to its signature index by exact tensor name. There is
+// deliberately no positional fallback: the signature keys are ordered
+// alphabetically and do not match the positional tensor order, so a wrong
+// binding would produce a silently wrong image instead of a crash.
+bool LookupTensor(const std::unordered_map<std::string, size_t> &index_map,
+                  const std::vector<litert::StringView> &names,
+                  const std::string &model_path, const char *tensor_name,
+                  size_t *index) {
+  auto it = index_map.find(tensor_name);
+  if (it == index_map.end()) {
+    LOG(ERROR) << "Model " << model_path << " has no tensor named '"
+               << tensor_name
+               << "'; its signature exposes: " << JoinNames(names);
+    return false;
+  }
+  *index = it->second;
+  return true;
+}
+
+// A buffer whose size does not match the shape this pipeline resized it to
+// means the model file is not the export this code was written for.
+bool CheckPackedSize(const litert::TensorBuffer &buffer, const TensorSpec &spec,
+                     const std::string &model_path) {
+  auto packed = buffer.PackedSize();
+  if (!packed) {
+    LOG(ERROR) << "PackedSize failed for '" << spec.name << "' of "
+               << model_path << ": " << packed.Error().Message();
+    return false;
+  }
+  const size_t expected = ElementCount(spec.dims) * kElementBytes;
+  if (*packed != expected) {
+    LOG(ERROR) << "Tensor '" << spec.name << "' of " << model_path << " holds "
+               << *packed << " bytes, expected " << expected;
+    return false;
+  }
+  return true;
+}
+
+// Compiles one model on the CPU accelerator, binds every tensor by name,
+// pins the batch dimension and creates the buffers that all invocations
+// reuse. On success `*input_indices` holds the signature index of each spec
+// in `input_specs`, in the same order.
+bool BuildModel(litert::Environment &env, const std::string &model_path,
+                int num_threads, const std::vector<TensorSpec> &input_specs,
+                const TensorSpec &output_spec, SDModel *model,
+                std::vector<size_t> *input_indices) {
+  auto options = litert::Options::Create();
+  if (!options) {
+    LOG(ERROR) << "Options::Create failed for " << model_path;
+    return false;
+  }
+  options->SetHardwareAccelerators(litert::HwAccelerators::kCpu);
+  if (num_threads > 0) {
+    auto cpu_options = options->GetCpuOptions();
+    if (cpu_options) {
+      cpu_options->SetNumThreads(num_threads);
+    } else {
+      LOG(WARNING) << "GetCpuOptions failed; using the default thread count";
+    }
+  }
+
+  auto compiled = litert::CompiledModel::Create(env, model_path, *options);
+  if (!compiled) {
+    LOG(ERROR) << "CompiledModel::Create failed for " << model_path << ": "
+               << compiled.Error().Message();
+    return false;
+  }
+  model->compiled =
+      std::make_unique<litert::CompiledModel>(std::move(*compiled));
+
+  auto input_names = model->compiled->GetSignatureInputNames(kSignatureIndex);
+  auto output_names = model->compiled->GetSignatureOutputNames(kSignatureIndex);
+  if (!input_names || !output_names) {
+    LOG(ERROR) << "Failed to read the signature tensor names of " << model_path;
+    return false;
+  }
+  const auto input_map = MakeIndexMap(*input_names);
+  const auto output_map = MakeIndexMap(*output_names);
+
+  input_indices->clear();
+  for (const auto &spec : input_specs) {
+    size_t index = 0;
+    if (!LookupTensor(input_map, *input_names, model_path, spec.name, &index)) {
+      return false;
+    }
+    input_indices->push_back(index);
+  }
+  if (!LookupTensor(output_map, *output_names, model_path, output_spec.name,
+                    &model->output_idx)) {
+    return false;
+  }
+
+  // Pin the shapes before the buffers are created: every input exports the
+  // batch dimension as dynamic (-1) and has no size until it is resized.
+  for (size_t i = 0; i < input_specs.size(); ++i) {
+    const std::vector<int> &dims = input_specs[i].dims;
+    auto resized = model->compiled->ResizeInputTensorNonStrict(
+        kSignatureIndex, (*input_indices)[i],
+        litert::Span<const int>(dims.data(), dims.size()));
+    if (!resized) {
+      LOG(ERROR) << "Failed to resize input '" << input_specs[i].name << "' of "
+                 << model_path << ": " << resized.Error().Message();
+      return false;
+    }
+  }
+
+  // Created once and reused by every invocation; the denoising loop must not
+  // reallocate them per step.
+  auto input_bufs = model->compiled->CreateInputBuffers(kSignatureIndex);
+  auto output_bufs = model->compiled->CreateOutputBuffers(kSignatureIndex);
+  if (!input_bufs || !output_bufs) {
+    LOG(ERROR) << "Failed to create the tensor buffers of " << model_path;
+    return false;
+  }
+  model->input_bufs = std::move(*input_bufs);
+  model->output_bufs = std::move(*output_bufs);
+
+  for (size_t i = 0; i < input_specs.size(); ++i) {
+    if (!CheckPackedSize(model->input_bufs[(*input_indices)[i]], input_specs[i],
+                         model_path)) {
+      return false;
+    }
+  }
+  return CheckPackedSize(model->output_bufs[model->output_idx], output_spec,
+                         model_path);
+}
+
+}  // namespace
+
+// Create a new backend and return the pointer to it.
 mlperf_backend_ptr_t StableDiffusionPipeline::backend_create(
-    const char* model_path, mlperf_backend_configuration_t* configs,
-    const char* native_lib_path) {
-  // The model_path received from main.cc or the app can be a file path or a
-  // directory path. Assuming for Stable Diffusion task, the model_path point
-  // to a directory where all model files are located and the file names are
-  // known beforehand.
+    const char *model_path, mlperf_backend_configuration_t *configs,
+    const char *native_lib_path) {
+  // model_path is a directory for this benchmark: it ships three models plus
+  // the timestep embedding table, and the filenames come from the settings.
 
   // Verify only one instance of the backend exists at any time
   if (backendExists) {
-    LOG(ERROR) << "Backend already exists";
+    LOG(ERROR) << "Only one backend instance should exist at a time";
     return nullptr;
   }
 
-  SDBackendData* backend_data = new SDBackendData();
+  auto *backend_data = new SDBackendData();
   backendExists = true;
 
-  // Read seed and num_steps value from SD task settings
-  backend_data->seed =
-      mlperf::mobile::GetConfigValue(configs, "stable_diffusion_seed", 0);
+  backend_data->seed = GetConfigInt(configs, "stable_diffusion_seed", 0);
   if (backend_data->seed == 0) {
     LOG(ERROR) << "Cannot get stable_diffusion_seed";
+    backend_delete(backend_data);
     return nullptr;
   }
   backend_data->num_steps =
-      mlperf::mobile::GetConfigValue(configs, "stable_diffusion_num_steps", 0);
-  if (backend_data->num_steps == 0) {
+      GetConfigInt(configs, "stable_diffusion_num_steps", 0);
+  if (backend_data->num_steps <= 0) {
     LOG(ERROR) << "Cannot get stable_diffusion_num_steps";
-    return nullptr;
-  }
-
-  std::string text_encoder_name = mlperf::mobile::GetConfigValue(
-      configs, "text_encoder_filename", std::string(""));
-  std::string diffusion_model_name = mlperf::mobile::GetConfigValue(
-      configs, "diffusion_model_filename", std::string(""));
-  std::string decoder_name = mlperf::mobile::GetConfigValue(
-      configs, "decoder_filename", std::string(""));
-  std::string timestep_embeddings_name = mlperf::mobile::GetConfigValue(
-      configs, "timestep_embeddings_filename", std::string(""));
-
-  std::string text_encoder_path =
-      std::string(model_path) + "/" + text_encoder_name;
-  std::string sd_model_path =
-      std::string(model_path) + "/" + diffusion_model_name;
-  std::string decoder_path = std::string(model_path) + "/" + decoder_name;
-  std::string ts_embedding_path =
-      std::string(model_path) + "/" + timestep_embeddings_name;
-
-  backend_data->text_encoder_model =
-      TfLiteModelCreateFromFile(text_encoder_path.c_str());
-  backend_data->sd_model = TfLiteModelCreateFromFile(sd_model_path.c_str());
-  backend_data->decoder_model = TfLiteModelCreateFromFile(decoder_path.c_str());
-
-  if (!backend_data->text_encoder_model || !backend_data->sd_model ||
-      !backend_data->decoder_model) {
-    delete backend_data;
-    return nullptr;
-  }
-
-  backend_data->text_encoder_interpreter =
-      create_interpreter(backend_data->text_encoder_model);
-  backend_data->sd_interpreter = create_interpreter(backend_data->sd_model);
-  backend_data->decoder_interpreter =
-      create_interpreter(backend_data->decoder_model);
-
-  if (!backend_data->text_encoder_interpreter ||
-      !backend_data->sd_interpreter || !backend_data->decoder_interpreter) {
     backend_delete(backend_data);
     return nullptr;
   }
+  const int num_threads = GetConfigInt(configs, "num_threads", 4);
+
+  const std::string text_encoder_name =
+      GetConfigString(configs, "text_encoder_filename", "");
+  const std::string diffusion_model_name =
+      GetConfigString(configs, "diffusion_model_filename", "");
+  const std::string decoder_name =
+      GetConfigString(configs, "decoder_filename", "");
+  const std::string timestep_embeddings_name =
+      GetConfigString(configs, "timestep_embeddings_filename", "");
+  if (text_encoder_name.empty() || diffusion_model_name.empty() ||
+      decoder_name.empty() || timestep_embeddings_name.empty()) {
+    LOG(ERROR) << "Missing a Stable Diffusion filename in the settings";
+    backend_delete(backend_data);
+    return nullptr;
+  }
+
+  const std::string dir = std::string(model_path) + "/";
+  const std::string text_encoder_path = dir + text_encoder_name;
+  const std::string diffusion_model_path = dir + diffusion_model_name;
+  const std::string decoder_path = dir + decoder_name;
+  const std::string timestep_embeddings_path = dir + timestep_embeddings_name;
+
+  // The shipped exports are dynamic_int8 (text encoder, diffusion) and
+  // dynamic_fp16 (decoder), aimed at CPU/XNNPACK; the settings only offer a
+  // CPU delegate for this benchmark.
+  if (configs->delegate_selected != nullptr &&
+      strcmp(configs->delegate_selected, "CPU") != 0) {
+    LOG(WARNING) << "Ignoring delegate_selected=" << configs->delegate_selected
+                 << "; the Stable Diffusion pipeline runs on the CPU";
+  }
+
+  // One environment shared by all three compiled models, as the LiteRT
+  // header recommends.
+  auto env = litert::Environment::Create({});
+  if (!env) {
+    LOG(ERROR) << "Environment::Create failed";
+    backend_delete(backend_data);
+    return nullptr;
+  }
+  backend_data->env = std::make_unique<litert::Environment>(std::move(*env));
+
+  // Signature input keys are alphabetical, so these lists are in role order,
+  // not tensor order: the text encoder's signature reads (positions,
+  // tokens), and the diffusion model's reads (context, latent,
+  // timestep_embedding).
+  const std::vector<TensorSpec> encoder_inputs = {
+      {"tokens", {1, kTokenCount}},
+      {"positions", {1, kTokenCount}},
+  };
+  const TensorSpec encoder_output = {"layer_normalization_72",
+                                     {1, kTokenCount, 768}};
+  const std::vector<TensorSpec> diffusion_inputs = {
+      {"latent", {1, 64, 64, 4}},
+      {"context", {1, kTokenCount, 768}},
+      {"timestep_embedding", {1, 1280}},
+  };
+  const TensorSpec diffusion_output = {"padded_conv2d_83", {1, 64, 64, 4}};
+  const std::vector<TensorSpec> decoder_inputs = {
+      {"input_1", {1, 64, 64, 4}},
+  };
+  const TensorSpec decoder_output = {"padded_conv2d_37", {1, 512, 512, 3}};
+
+  std::vector<size_t> indices;
+  if (!BuildModel(*backend_data->env, text_encoder_path, num_threads,
+                  encoder_inputs, encoder_output, &backend_data->text_encoder,
+                  &indices)) {
+    backend_delete(backend_data);
+    return nullptr;
+  }
+  backend_data->encoder_tokens_idx = indices[0];
+  backend_data->encoder_positions_idx = indices[1];
+
+  if (!BuildModel(*backend_data->env, diffusion_model_path, num_threads,
+                  diffusion_inputs, diffusion_output, &backend_data->diffusion,
+                  &indices)) {
+    backend_delete(backend_data);
+    return nullptr;
+  }
+  backend_data->diffusion_latent_idx = indices[0];
+  backend_data->diffusion_context_idx = indices[1];
+  backend_data->diffusion_timestep_idx = indices[2];
+
+  if (!BuildModel(*backend_data->env, decoder_path, num_threads, decoder_inputs,
+                  decoder_output, &backend_data->decoder, &indices)) {
+    backend_delete(backend_data);
+    return nullptr;
+  }
+  backend_data->decoder_latent_idx = indices[0];
 
   if (!EmbeddingManager::getInstance().load_timestep_embeddings(
-          ts_embedding_path)) {
+          timestep_embeddings_path)) {
     LOG(ERROR) << "Failed to load timestep embeddings from "
-               << ts_embedding_path;
+               << timestep_embeddings_path;
     backend_delete(backend_data);
     return nullptr;
   }
+
+  // The unconditional prompt is constant: a start token, then padding.
+  backend_data->unconditional_tokens.assign(kTokenCount, kEndOfTextToken);
+  backend_data->unconditional_tokens[0] = kStartOfTextToken;
+  backend_data->input_prompt_tokens.assign(kTokenCount, 0);
 
   return backend_data;
 }
 
-TfLiteInterpreter* StableDiffusionPipeline::create_interpreter(
-    TfLiteModel* model) {
-  TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
-  TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
-  TfLiteInterpreterOptionsDelete(options);
-
-  if (TfLiteInterpreterAllocateTensors(interpreter) != kTfLiteOk) {
-    TfLiteInterpreterDelete(interpreter);
-    return nullptr;
-  }
-
-  return interpreter;
-}
-
-const char* StableDiffusionPipeline::backend_vendor_name(
+// Vendor name who create this backend.
+const char *StableDiffusionPipeline::backend_vendor_name(
     mlperf_backend_ptr_t backend_ptr) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
+  auto *backend_data = static_cast<SDBackendData *>(backend_ptr);
   return backend_data->vendor;
 }
 
-const char* StableDiffusionPipeline::backend_accelerator_name(
+// Return the name of the accelerator.
+const char *StableDiffusionPipeline::backend_accelerator_name(
     mlperf_backend_ptr_t backend_ptr) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
+  auto *backend_data = static_cast<SDBackendData *>(backend_ptr);
   return backend_data->accelerator;
 }
 
-const char* StableDiffusionPipeline::backend_name(
+// Return the name of this backend.
+const char *StableDiffusionPipeline::backend_name(
     mlperf_backend_ptr_t backend_ptr) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
+  auto *backend_data = static_cast<SDBackendData *>(backend_ptr);
   return backend_data->name;
 }
 
+// Destroy the backend pointer and its data.
 void StableDiffusionPipeline::backend_delete(mlperf_backend_ptr_t backend_ptr) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
-  if (backend_data) {
-    TfLiteModelDelete(backend_data->text_encoder_model);
-    TfLiteModelDelete(backend_data->sd_model);
-    TfLiteModelDelete(backend_data->decoder_model);
-    delete backend_data;
-  }
+  // ~SDBackendData tears the LiteRT objects down in reverse declaration
+  // order, which gives buffers, then compiled models, then the shared
+  // environment. Safe on a partially built backend: every member is RAII.
+  delete static_cast<SDBackendData *>(backend_ptr);
   backendExists = false;
 }
 
+// Run the inference for a sample.
 mlperf_status_t StableDiffusionPipeline::backend_issue_query(
-    mlperf_backend_ptr_t backend_ptr, ft_callback callback, void* context) {
-  SDBackendData* backend_data = (SDBackendData*)backend_ptr;
-  StableDiffusionInvoker* invoker = new StableDiffusionInvoker(backend_data);
-  backend_data->output = invoker->invoke();
+    mlperf_backend_ptr_t backend_ptr, ft_callback callback, void *context) {
+  auto *backend_data = static_cast<SDBackendData *>(backend_ptr);
+  StableDiffusionInvoker invoker(backend_data);
+  if (!invoker.invoke(&backend_data->output)) {
+    LOG(ERROR) << "Stable Diffusion inference failed";
+    return MLPERF_FAILURE;
+  }
   return MLPERF_SUCCESS;
 }
 
+// Flush the staged queries immediately.
 mlperf_status_t StableDiffusionPipeline::backend_flush_queries(
     mlperf_backend_ptr_t backend_ptr) {
   return MLPERF_SUCCESS;
 }
 
+// Return the number of inputs of the model.
 int32_t StableDiffusionPipeline::backend_get_input_count(
     mlperf_backend_ptr_t backend_ptr) {
   return 1;
 }
 
+// Return the type of the ith input: the text encoder's "tokens" tensor.
 mlperf_data_t StableDiffusionPipeline::backend_get_input_type(
     mlperf_backend_ptr_t backend_ptr, int32_t i) {
-  // Cast the backend pointer to SDBackendData
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
-
-  // Initialize the result with a default type and size
   mlperf_data_t result;
-  result.type = mlperf_data_t::Float32;  // Default type, will be updated below
-  result.size = 0;
-
-  const TfLiteTensor* tensor = nullptr;
-
-  switch (i) {
-    case 0:
-      tensor = TfLiteInterpreterGetInputTensor(
-          backend_data->text_encoder_interpreter, 0);
-      break;
-    default:
-      std::cerr << "Unsupported input index: " << i << std::endl;
-      return result;
+  result.type = mlperf_data_t::Int32;
+  result.size = kTokenCount;
+  if (i != 0) {
+    LOG(ERROR) << "Unsupported input index: " << i;
+    result.size = 0;
   }
-
-  if (tensor) {
-    // Map the TensorFlow Lite type to mlperf_data_t::Type
-    result.type = TfType2Type(TfLiteTensorType(tensor));
-    // Calculate the total number of elements in the tensor
-    result.size = LiteRTNumElements(tensor);
-  } else {
-    std::cerr << "Failed to retrieve tensor for input index: " << i
-              << std::endl;
-  }
-
   return result;
 }
 
+// Set the data for ith input.
 mlperf_status_t StableDiffusionPipeline::backend_set_input(
     mlperf_backend_ptr_t backend_ptr, int32_t batchIndex, int32_t i,
-    void* data) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
-
-  int* tokens = static_cast<int*>(data);
-  size_t token_count = 0;
-  while (tokens[token_count] != 0) {
-    ++token_count;
+    void *data) {
+  auto *backend_data = static_cast<SDBackendData *>(backend_ptr);
+  if (i != 0 || data == nullptr) {
+    LOG(ERROR) << "Unsupported input index: " << i;
+    return MLPERF_FAILURE;
   }
 
-  std::vector<int> unconditioned_tokens(77, 49407);
-  unconditioned_tokens[0] = 49406;
+  // The dataset hands over a zero-terminated token array sized for the
+  // encoder input; stop at the terminator but never scan past the tensor.
+  const int *tokens = static_cast<const int *>(data);
+  int token_count = 0;
+  while (token_count < kTokenCount && tokens[token_count] != 0) ++token_count;
 
-  backend_data->input_prompt_tokens.assign(tokens, tokens + token_count);
-  backend_data->unconditional_tokens.assign(unconditioned_tokens.begin(),
-                                            unconditioned_tokens.end());
-
+  // Rewrite the whole tensor length so no tail from the previous sample
+  // survives into this run.
+  backend_data->input_prompt_tokens.assign(kTokenCount, 0);
+  std::copy(tokens, tokens + token_count,
+            backend_data->input_prompt_tokens.begin());
   return MLPERF_SUCCESS;
 }
 
+// Return the number of outputs for the model.
 int32_t StableDiffusionPipeline::backend_get_output_count(
     mlperf_backend_ptr_t backend_ptr) {
   return 1;
 }
 
+// Return the type of ith output: the decoder's RGB image.
 mlperf_data_t StableDiffusionPipeline::backend_get_output_type(
     mlperf_backend_ptr_t backend_ptr, int32_t i) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
-
   mlperf_data_t result;
   result.type = mlperf_data_t::Float32;
-  result.size = 0;
-
-  const TfLiteTensor* tensor = nullptr;
-
-  switch (i) {
-    case 0:
-      tensor = TfLiteInterpreterGetOutputTensor(
-          backend_data->decoder_interpreter, 0);
-      break;
-    default:
-      std::cerr << "Unsupported output index: " << i << std::endl;
-      return result;
+  result.size = kImageElements;
+  if (i != 0) {
+    LOG(ERROR) << "Unsupported output index: " << i;
+    result.size = 0;
   }
-
-  if (tensor) {
-    result.type = TfType2Type(TfLiteTensorType(tensor));
-    result.size = LiteRTNumElements(tensor);
-  } else {
-    std::cerr << "Failed to retrieve tensor for output index: " << i
-              << std::endl;
-  }
-
   return result;
 }
 
+// Get the data from ith output.
 mlperf_status_t StableDiffusionPipeline::backend_get_output(
     mlperf_backend_ptr_t backend_ptr, uint32_t batchIndex, int32_t i,
-    void** data) {
-  SDBackendData* backend_data = static_cast<SDBackendData*>(backend_ptr);
-
-  if (i == 0) {
-    *data = backend_data->output.data();
-    return MLPERF_SUCCESS;
+    void **data) {
+  auto *backend_data = static_cast<SDBackendData *>(backend_ptr);
+  if (i != 0) {
+    LOG(ERROR) << "Unsupported output index: " << i;
+    return MLPERF_FAILURE;
   }
-
-  return MLPERF_FAILURE;
+  if (backend_data->output.size() != static_cast<size_t>(kImageElements)) {
+    LOG(ERROR) << "Decoded image holds " << backend_data->output.size()
+               << " floats, expected " << kImageElements;
+    return MLPERF_FAILURE;
+  }
+  // Points into the member staging vector, so it stays valid after this
+  // call returns.
+  *data = backend_data->output.data();
+  return MLPERF_SUCCESS;
 }
 
 void StableDiffusionPipeline::backend_convert_inputs(
     mlperf_backend_ptr_t backend_ptr, int bytes, int width, int height,
-    uint8_t* data) {}
+    uint8_t *data) {}
 
 void StableDiffusionPipeline::backend_convert_outputs(
     mlperf_backend_ptr_t backend_ptr, int bytes, int width, int height,
-    uint8_t* data) {}
+    uint8_t *data) {}
 
-void* StableDiffusionPipeline::backend_get_buffer(size_t n) {
+void *StableDiffusionPipeline::backend_get_buffer(size_t n) {
   return ::operator new(n);
 }
 
-void StableDiffusionPipeline::backend_release_buffer(void* p) {
+void StableDiffusionPipeline::backend_release_buffer(void *p) {
   ::operator delete(p);
 }
-
-#ifdef __cplusplus
-}
-#endif  // __cplusplus

--- a/mobile_back_litert/cpp/backend_litert/stable_diffusion_pipeline.h
+++ b/mobile_back_litert/cpp/backend_litert/stable_diffusion_pipeline.h
@@ -13,35 +13,63 @@ limitations under the License.
 #ifndef LITERT_STABLE_DIFFUSION_PIPELINE_H_
 #define LITERT_STABLE_DIFFUSION_PIPELINE_H_
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <vector>
 
-#include "absl/log/log.h"
 #include "flutter/cpp/c/type.h"
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_tensor_buffer.h"
 #include "pipeline.h"
-#include "tflite/c/c_api.h"
-#include "thread_pool.h"
+
+// One stage of the Stable Diffusion pipeline: a compiled model plus the
+// tensor buffers every invocation reuses.
+//
+// Declaration order matters: members are destroyed in reverse order, and the
+// buffers must go before the compiled model they were created from.
+struct SDModel {
+  std::unique_ptr<litert::CompiledModel> compiled;
+  std::vector<litert::TensorBuffer> input_bufs;
+  std::vector<litert::TensorBuffer> output_bufs;
+
+  // Signature index of the model's single output, resolved by name.
+  size_t output_idx = 0;
+};
 
 struct SDBackendData {
   const char *name = "LiteRT";
   const char *vendor = "Google";
   const char *accelerator = "CPU";
 
-  TfLiteModel *text_encoder_model{nullptr};
-  TfLiteModel *sd_model{nullptr};
-  TfLiteModel *decoder_model{nullptr};
+  // Declaration order matters here too: the three compiled models (and the
+  // buffers inside them) must be destroyed before the environment they
+  // share, so the environment is declared first and destroyed last.
+  std::unique_ptr<litert::Environment> env;
+  SDModel text_encoder;
+  SDModel diffusion;
+  SDModel decoder;
 
-  TfLiteInterpreter *text_encoder_interpreter{nullptr};
-  TfLiteInterpreter *sd_interpreter{nullptr};
-  TfLiteInterpreter *decoder_interpreter{nullptr};
+  // Signature input indices, resolved by name at create time. The signature
+  // input keys are ordered alphabetically, which does not match the
+  // positional tensor order, so none of these may be assumed.
+  size_t encoder_tokens_idx = 0;
+  size_t encoder_positions_idx = 0;
+  size_t diffusion_latent_idx = 0;
+  size_t diffusion_context_idx = 0;
+  size_t diffusion_timestep_idx = 0;
+  size_t decoder_latent_idx = 0;
 
-  std::vector<int> input_prompt_tokens;
-  std::vector<int> unconditional_tokens;
+  std::vector<int32_t> input_prompt_tokens;
+  std::vector<int32_t> unconditional_tokens;
 
-  int num_steps{20};
-  int seed{633994880};
+  int num_steps = 20;
+  int seed = 633994880;
 
+  // Host staging for the decoded image: backend_get_output hands out a
+  // pointer into it, so it has to stay valid after the call returns.
   std::vector<float> output;
-  std::unique_ptr<Threadpool> executer;
 };
 
 // A pipeline for Stable Diffusion.
@@ -98,9 +126,6 @@ class StableDiffusionPipeline : public Pipeline {
   void *backend_get_buffer(size_t n) override;
 
   void backend_release_buffer(void *p) override;
-
- private:
-  TfLiteInterpreter *create_interpreter(TfLiteModel *model);
 };
 
 #endif  // LITERT_STABLE_DIFFUSION_PIPELINE_H_


### PR DESCRIPTION
Ports the dormant stable-diffusion pipeline to the LiteRT 2.1.5 CompiledModel API and wires it in, closing the last benchmark gap on this backend. Targets `litert`, not master.

### How it works
- Three models (text encoder, diffusion, decoder) share one `litert::Environment`; 43 invocations per query at the shipped `num_steps: 20`. Buffers are created once and reused across the denoising loop.
- **Inputs are bound by signature name, never by position.** The signature keys are ordered alphabetically, which does not match tensor order: the text encoder reads `(positions, tokens)` and the diffusion model reads `(context, latent, timestep_embedding)`. Binding positionally would swap latent with context - both float32, so it would produce a plausible but wrong image rather than an error. A missing name is a hard failure that logs the names actually found.
- CPU only. The shipped exports are `dynamic_int8` (encoder, diffusion) and `dynamic_fp16` (decoder), aimed at CPU/XNNPACK; a GPU choice would need dedicated fp32 exports. Despite the filenames, nothing is quantized at the graph boundary - encoder inputs are int32, everything else float32. The delegate is labelled `CPU`/`cpu` accordingly, rather than copying the TFLite entry's `NNAPI`/`npu` labels, which are cosmetic (that code attaches no delegate).
- No new model exports and no `tasks.pbtxt` change: the existing v5_0 TFLite SD models are plain flatbuffers and load as-is. All four checksums were verified against the downloaded files.

### Test coverage, and its limit
Stable diffusion joins the LLM benchmarks in `quickRun`. In accuracy mode loadgen ignores `min_query_count` and runs the whole set - here 150 sequential 20-step generations plus 150 CLIP scoring passes and a 1.71 GB ground-truth download, which is hours on a CPU against a 90-minute job. `quickRun` keeps the time-bounded performance phase.

The consequence is worth stating plainly: **CI exercises the pipeline end to end but cannot catch a wrong-but-plausible image**, because nothing scores the output. Name-based binding plus hard failure on a missing name is what guards correctness instead.

The QTI-only gate in `canRunBenchmark` is widened for LiteRT by inverting the condition rather than adding `|| litert`, so QTI behaviour is bit-identical and SD does not start running on the Samsung and MediaTek jobs, which would add ~2.8 GB of downloads and an uncapped CPU run to three more device budgets.

### Defects fixed in the dormant sources
Carried over from the TFLite twin, all pre-existing: `exit(-1)` on inference failure now returns `MLPERF_FAILURE`; the per-query invoker leak is gone; the unbounded scan for a token terminator is bounded at 77 and the token tail zero-padded, so no stale data from a previous sample reaches the model; the cumulative-alpha index is bounds-checked; the embeddings loader validates its reads before allocating. Dead code dropped: `get_tensor_index_by_name`, two unused `get_timestep_embedding` implementations, and a `main()` behind `__TEST_BPE__`.

Note these files were byte-identical to `mobile_back_tflite`'s copies, so they now diverge - the same defects remain in the TFLite backend and are worth a follow-up there.

### Verification
Confirmed on a Pixel 10 Pro (run 33053477420). Stable diffusion ran end to end on `liblitertbackend`: the pipeline initialised, all six tensors resolved by signature name with no binding failure, and both samples completed the full 20-step denoising loop - 111.31 s mean latency per image (111.71 s p90), 0.00895 QPS, 2 samples in 229.9 s. `isResultValid` is false only because the min-query rule (2 vs 128) is unmet under the time-bounded run, exactly as the LLM benchmarks behave.

Two incidental fixes rode along, both surfaced by this work:
- `checkAccuracy` dereferenced `accuracyRun` with a null check operator, which is null in `quickRun`. The LLM benchmarks never hit it only because their expected-accuracy maps are empty and return early. The run mode's own `doAccuracyRun` flag is now threaded through from the call site, so the check is skipped only when the mode genuinely has no accuracy phase - rather than whenever the field happens to be null, which would silently stop checking benchmarks that should have one.
- The BrowserStack trigger retry went from 2 attempts to 8. The device jobs have no `concurrency:` group, so two boards at once exhaust the account's parallel budget and every loser fails outright with `BROWSERSTACK_ALL_PARALLELS_IN_USE` - no session created, nothing run. That cost four device-job failures on this branch that looked like code failures. `retry_on_exit_code: 9` is specifically the trigger failure, so this only lengthens how long a job waits for a slot; everything else still fails fast. A concurrency group would address the cause rather than the symptom, but it changes scheduling for every board and belongs in its own change.

Build side: the sources type-check against the pinned LiteRT headers and compile under Code Analysis with `WITH_LITERT=1`; `dart analyze`, `dart format`, `clang-format` and `buildifier` are clean; the settings block parses under `protoc`; the four model checksums match the md5s of the actually-downloaded files.

